### PR TITLE
Dereference AudioBufferSourceNode to fix iOS memory leak

### DIFF
--- a/src/webaudio/WebAudioInstance.ts
+++ b/src/webaudio/WebAudioInstance.ts
@@ -497,6 +497,7 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
             this._source.onended = null;
             this._source.stop(0); // param needed for iOS 8 bug
             this._source.disconnect();
+            this._source.buffer = null;
             this._source = null;
         }
     }
@@ -509,6 +510,7 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
             this.enableTicker(false);
             this._source.onended = null;
             this._source.disconnect();
+            this._source.buffer = null;
         }
         this._source = null;
         this._progress = 1;

--- a/src/webaudio/WebAudioMedia.ts
+++ b/src/webaudio/WebAudioMedia.ts
@@ -52,6 +52,7 @@ class WebAudioMedia implements IMedia
         this.parent = null;
         this._nodes.destroy();
         this._nodes = null;
+        this._source.buffer = null;
         this._source = null;
         this.source = null;
     }


### PR DESCRIPTION
After prolonged loading/unloading sounds, iOS Safari (and likely any other browser on iOS) will crash ("This page was reloaded because there was a problem"), because of an internal leak related to AudioBufferSourceNodes. The problem was fixed in SoundJS in this way: https://github.com/CreateJS/SoundJS/pull/203

The referenced solution replaces the buffer with a 1-sample long buffer, wrapped in a try-catch to avoid FF/Chrome exceptions for modifying buffer. My solution replaces it with `null`, and does not require a try-catch in major current browsers. At the time of the referenced solution, it was alleged that setting `buffer` to null will cause an exception, but on current platforms, I have not found this to be the case. This code has been tested on recent versions of Safari, Firefox, Chrome, and Edge without producing any errors. I'm happy to rewrite this using the 1-sample-long buffer solution to avoid any potential issues in old browsers if that is preferred.

To verify the issue and fix, load and unload sounds repeatedly. The test I've been using loads and unloads ~50 sounds every 5 seconds or so, playing 2 of them between loads. More (and/or longer?) sounds can reproduce the issue more quickly. Consistently, after ~3 minutes of this, the Safari tab on iPhone 6 will crash. With this change it appears to be able to run this test indefinitely.