### PR TITLE
Fix IMediaInstance interface event off callback type

### DIFF
--- a/src/interfaces/IMediaInstance.ts
+++ b/src/interfaces/IMediaInstance.ts
@@ -110,8 +110,7 @@ interface IMediaInstance
     on(event: 'progress', fn: (progress: number, duration: number) => void, context?: any): this;
     on(event: 'resumed' | 'paused' | 'start' | 'end' | 'stop', fn: () => void, context?: any): this;
     off(event: 'resumed' | 'paused' | 'start' | 'end' | 'progress' | 'pause' | 'stop',
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        fn: Function, context?: any, once?: boolean): this;
+        fn?: (...args: any[]) => void, context?: any, once?: boolean): this;
 
     /**
      * Fired when the sound when progress updates.


### PR DESCRIPTION
Fixes #165

I changed the `IMediaInstance.off` handler type to match the one in `EventEmitter3`. This fixes the type incompatibility with strict mode when trying to assign `HTMLAudioMedia` to `IMedia` (and other similar cases).

Note that the incompatibility was most likely due to the missing `?` in `fn: Function`, which with strict null checks types the variable as `Function | undefined` instead of just `Function` but I went ahead and changed it to `(...args: any[]) => void` to get rid of the linter hack. That type should be compatible with anything that you can pass to `on` and `once` so we should be good.
