### PR TITLE
add AudioBuffer as source of Sound

### DIFF
--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -64,7 +64,7 @@ interface Options {
      * If sound is already preloaded, available.
      * @type {ArrayBuffer|HTMLAudioElement}
      */
-    source?: ArrayBuffer | HTMLAudioElement;
+    source?: ArrayBuffer | AudioBuffer | HTMLAudioElement;
     /**
      * The map of sprite data. Where a sprite is an object
      * with a `start` and `end`, which are the times in seconds. Optionally, can include
@@ -266,11 +266,11 @@ class Sound
 
     /**
      * Create a new sound instance from source.
-     * @param {ArrayBuffer|String|Options|HTMLAudioElement} options - Either the path or url to the source file.
+     * @param {ArrayBuffer|AudioBuffer|String|Options|HTMLAudioElement} options - Either the path or url to the source file.
      *        or the object of options to use.
      * @return Created sound instance.
      */
-    public static from(source: string | Options | ArrayBuffer | HTMLAudioElement): Sound
+    public static from(source: string | Options | ArrayBuffer | HTMLAudioElement | AudioBuffer): Sound
     {
         let options: Options = {};
 
@@ -278,7 +278,7 @@ class Sound
         {
             options.url = source as string;
         }
-        else if (source instanceof ArrayBuffer || source instanceof HTMLAudioElement)
+        else if (source instanceof ArrayBuffer || source instanceof AudioBuffer || source instanceof HTMLAudioElement)
         {
             options.source = source;
         }

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -324,6 +324,25 @@ export function suite(useLegacy = false): void
             expect(s.sprites.foo.parent).to.equal(s);
             expect(s.sprites.bar.parent).to.equal(s);
         });
+
+        it('should take AudioBuffer as source', webAudioOnly(function (this: Mocha, done: () => void)
+        {
+            this.slow(300);
+            const s = utils.sineTone(200, 0.1);
+            const buffer = (s.media as any).buffer as AudioBuffer;
+
+            expect(buffer).to.be.instanceOf(AudioBuffer);
+
+            const sound = Sound.from(buffer);
+
+            sound.volume = 0;
+            sound.play(() =>
+            {
+                done();
+            });
+            expect(sound.duration).to.equal(0.1);
+            expect(sound.isPlaying).to.be.true;
+        }));
     });
 
     describe(`PIXI.sound.SoundInstance${suffix}`, function ()


### PR DESCRIPTION
### Resolves

- Resolves #177 

### Proposed Changes

`Sound.from` can take `AudioBuffer` as `source`

### Reason for Changes

To support `AudioBuffer` to be played

### Test Coverage

- [x] code lint
- [x] test passes
- [x] docs updated
