### PR TITLE
Add singleInstance to play options

### DIFF
--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -125,6 +125,12 @@ interface PlayOptions {
      * @type {Function}
      */
     loaded?: LoadedCallback;
+    /**
+     * Setting `true` will stop any playing instances. This is the same as
+     * the singleInstance property on Sound, but is play-specific.
+     * @type {boolean}
+     */
+    singleInstance?: boolean;
 }
 
 /**
@@ -643,7 +649,7 @@ class Sound
         }
 
         // Stop all sounds
-        if (this.singleInstance)
+        if (this.singleInstance || options.singleInstance)
         {
             this._removeInstances();
         }

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { expect } from 'chai';
-import { sound, Sound, utils, webaudio, htmlaudio, filters, SoundLibrary, IMediaInstance } from '../';
+import { sound, Sound, utils, webaudio, htmlaudio, filters, SoundLibrary, IMediaInstance } from '../src';
 import path from 'path';
 
 declare global {
@@ -147,6 +147,20 @@ export function suite(useLegacy = false): void
 
             instance.stop();
             expect(s.instances.length).to.equal(3);
+            s.stop();
+            expect(s.instances.length).to.equal(0);
+        });
+
+        it('should play with single instance param', function ()
+        {
+            const s = sound.find('alert-4');
+
+            s.play();
+            s.play();
+            s.play();
+            expect(s.instances.length).to.equal(3);
+            s.play({ singleInstance: true });
+            expect(s.instances.length).to.equal(1);
             s.stop();
             expect(s.instances.length).to.equal(0);
         });


### PR DESCRIPTION
Fixes #144

This feature addition allows passing `singleInstance` property to the play function. This works like the Sound property by the same name, but is play specific.

```js
const instance = sound.play('something', { singleInstance: true });
```