### PR TITLE
Add support for GlobalMixins

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+declare namespace GlobalMixins
+{
+    // PixiJS 6.1+ supports mixin types for LoaderResource
+    interface LoaderResource
+    {
+        /** Reference to Sound object created. */
+        sound?: import('./').Sound;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "mkdirp": "^0.5.1",
         "npm-run-all": "^4.1.5",
         "nyc": "^14.1.0",
-        "pixi.js": "^6.0.0",
+        "pixi.js": "^6.2.1",
         "pre-commit": "^1.2.2",
         "rimraf": "^2.6.3",
         "rollup": "^2.0.0",
@@ -625,82 +625,69 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.0.2.tgz",
-      "integrity": "sha512-zHJcrGmpphnqjUQr+5HhcoInuKxZu3PxGl/NRgTC5gpWp259D0LBPT7k3Lt45r4kruDCMUGpMZVb1s46IZniSQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.2.1.tgz",
+      "integrity": "sha512-zXgXx3BostasR69a68BDGVMEjL5CWBct+LtongU1T8HgdXbu2BPaZ/Z679pMj23+5oAR0mUeoH7qTTyRQ2kS3g==",
       "dev": true,
-      "dependencies": {
-        "@pixi/canvas-renderer": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.0.2.tgz",
-      "integrity": "sha512-zHCzO0K5jJ48ngbH4FpdYJh1LxuGn9mJSIOF8YorqXFt+3drM9R9/qGGfSGdA9O7rW0O0uIkSndQwPXIlOIsUA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.2.1.tgz",
+      "integrity": "sha512-J1dlu4PTF6O9WfHKTs0pg3NSePW2+8M2yMrivR7R/Z3CmmebnRiquua7U/avQXkLVJBwGdSyij2e6fN8dvnUXw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2"
-      }
-    },
-    "node_modules/@pixi/canvas-renderer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.0.2.tgz",
-      "integrity": "sha512-SL3pLxAjEQdVN8Tp/p2svciKeA0DRH7HhlO95frVwxzvG4Z3GGYU39f3ejtCaLPqLGzEJmLND7lbIXh0b+Ornw==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1"
       }
     },
     "node_modules/@pixi/compressed-textures": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.0.2.tgz",
-      "integrity": "sha512-SDuCLn/IEo8j1O+OYPVYy3Dz8+jAXLPdJsMYfs4GOGhsQWZ9js5bfLXWuwr6QRPOXoR3e8zb9qC3co8149pNLg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.2.1.tgz",
+      "integrity": "sha512-ZtmitA5ClIBqBo/dR1pd2n/y/xxOC+UKAj1S04FZiXaekYjmcsPUKxbq2Mgp8Qk2PBdz98HSQ4/xOGAYBMWrdQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/loaders": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/loaders": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.0.2.tgz",
-      "integrity": "sha512-4GSVKWr+qtjTj8IpRjXSnpkhF944ybjTSz9FnoqZZJgFxh/+9r53StHEGtKoK+BsSrmqbGzWax9krfc620KcLA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.2.1.tgz",
+      "integrity": "sha512-Dppt6rjYP4mIvJCY1I38XhPSfXoOm+A+ERKljLjcvcxVAMhqCTVz3YMp2cUzaio6DtQutiQ6tT06M40xlBZ/lA=="
     },
     "node_modules/@pixi/core": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.0.2.tgz",
-      "integrity": "sha512-Bz0WQDncrXuLEjU6pX5INrCLd5UorgBfufgysQzncOITIER4sZjAq5R/mCS1M3d4mGFhXZQyMyQK+O4LacWvOQ==",
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/runner": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      },
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-Ndh4/sNXWEkDeU5waWBCsMMPPaQv5uXLyepPXJE0emHBtgJOjKEHa79hrr0p1I2KN7Q8+mw8WlK55yVGuHroIA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/runner": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/ticker": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.0.2.tgz",
-      "integrity": "sha512-5qJxwT07McA7EK2yFhqvAjEJpap4Xa2hUCRDfsxl+Fu1Y3zDNBKI7HB8+mWZdYtSnnh5fJxrrw5lPo4HX7M+6w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.2.1.tgz",
+      "integrity": "sha512-4taHTgQeAWXrxB4WV0CsyarFEVuI8seKU+12S57c8nQGRYESfDUx4jFatWfgMHY2xCNwCdPTCvlSJzT5ou8VWA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/math": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/eslint-config": {
@@ -718,193 +705,191 @@
       }
     },
     "node_modules/@pixi/extract": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.0.2.tgz",
-      "integrity": "sha512-vGrewyLREzZOGAjcJO60s7oDm8ATbJOB5KyxuJXOSmIuhEmP69ohmxt1Rk6W8nfUS5m3gYU2KsY//RfDghHzVA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.2.1.tgz",
+      "integrity": "sha512-11MTxqXaZlsYRf9QumEDqZXoTb2RlIwpL42k7CnY7ycP+pu8TV+HB5NfLzFltCjnzXuBbl0/bz8eYeU5cSlVkA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.0.2.tgz",
-      "integrity": "sha512-fk7I2mCdQLbt9KrxiCd1103okSoNGXnxa1uY1V66jouSo51IXB3PkNEIFbET/cYOM7kKiMui20sYath1g596ag==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.2.1.tgz",
+      "integrity": "sha512-f/xSY+T9JnpzrtB2F1EOsGr6urgln6Wdr/NQgVk13L/g8jrM/PhMlbDsodEwf5IL/2xRjAFwYjCFMgzWVXALkw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.0.2.tgz",
-      "integrity": "sha512-FzaIl4l10lOW4+1SWFjLvK3MtH66zBG1SEa/cMUcVOfwZRIrg5pY3X842kZhNErm42yr9N2xBtKwwVBqQRbV8w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.2.1.tgz",
+      "integrity": "sha512-5pIcdL4u5WAwGHsI8uNovb4iK50l+7Dz1ZIwuwbkGU8Xoti/dzeox4bgywnXPq+yN33/Ty0nwd7VYuHmaNl/Rw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/settings": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/settings": "6.2.1"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.0.2.tgz",
-      "integrity": "sha512-zOKdURfQFBIqknpisG1Ow7BiYD7zVTAHU/Y4aPNBFwcAxET/fKFDB8vJFztO1g0C4v05ivjVXmvAuIAjlXdOhw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.2.1.tgz",
+      "integrity": "sha512-f3yyaruhr8lAVv13YpMb5L4yolvuTygq05CvM3OIFK+dP5bYar2cajGc1Zu0bR3VGF03N8JeHxCUwfMwV7V7AA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.0.2.tgz",
-      "integrity": "sha512-ozhpQ0YkGxsMDzE8u/zTYp0LZ52VBM849iCIqY/WSVZkjeNYB0XhUZdI/7RMDPMVfiQSENimacEpsOgzsOIPSA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.2.1.tgz",
+      "integrity": "sha512-o/MjC3tz1y3qZwf22FThGSqfn+zN5bMaBoXn+xSfCqC48thg9vgl2REq0jerDDMVSMW8vUvBUARfT+Wfm3SMDw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/math": "6.2.1"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.0.2.tgz",
-      "integrity": "sha512-dkX2udy4CqUuAS5yEu3udzdCbpZVdHgoVEksSiFiGzyC17uexkHaunQAgLb2UFGmjbdLT4Vk2FIrgM3+sMWQ3w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.2.1.tgz",
+      "integrity": "sha512-mIiAhBBDrOOPm1UF4isp7ti3d0y1y0xIZJnYbi15/Stmi1EQsMckDKg+V5uq9qbSm1jP3KoYq9dd7Oz/lr9srw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.0.2.tgz",
-      "integrity": "sha512-UnaRYV06qWe7ytBHZ8hK6ZH8Bnqhwtuhoj86pAv0Jhc8EXwcKC2wLT7JDFxBnjB1GwJuWDYnNrQpPsyRQsHNiA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.2.1.tgz",
+      "integrity": "sha512-jDIKo65p1VbqfUKuvb9UaNWaL4SRoc0SMYUwhSJcPjaWKv5bl7Ifqa6b/iQ31ZGHZGSot2ypwFeBiZLG1ndInQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.0.2.tgz",
-      "integrity": "sha512-/hONnNsWIo8O/0yQf2voBRi0aLnt7RXHXiYLb1d0bMkfYVHbn6r+TYZsz/mjOC1MRW+B0Bkh5ZxRWOgF3IpCiA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.2.1.tgz",
+      "integrity": "sha512-/MQREXYx+/glVAQLyNTLnd9+C1Bktm/F1XDzu5swDQSRH2Fo1rCh3mPw0dmJmrWrOOpBTO2+W7Kgm6NkENw9qA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/sprite": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.0.2.tgz",
-      "integrity": "sha512-YRT1reJXISgAf1+lRECpchR7+MUcGA/vdC612oG0fbrONCI0r1jMwMjdEcTnuMzZrzfSGL6yz0pkhIjWMjuY0g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.2.1.tgz",
+      "integrity": "sha512-WsubcDQt447+JtDhDHNfkmkEah4Ytry5WYIKbUZSvBdIc9LVXHPLQ+gM4mKkprEV8ZsQb6H/NbmtIKxjxHGYvw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/ticker": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.0.2.tgz",
-      "integrity": "sha512-ir71du5YOoH/NW8/rNwQ5br+YCVcKWUAltsUaQfTCMLjPzaT8nHtsBiy/krQIGNus179l1h7NfGrSOK/RU936Q==",
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/utils": "6.0.2",
-        "resource-loader": "^3.0.1"
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.2.1.tgz",
+      "integrity": "sha512-UB1uYb3HL4uN1q+w916DNLIZzz7gkg3p4QQRmBXq08Dnj8DWCghPRAfTGfCu3ORqYqEwSaZ+ulLT+SRfHryvyQ==",
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.0.2.tgz",
-      "integrity": "sha512-eA4VmqkWTUSRl1iYIu3sCitbg8+QfohU0Zk/61J1s0pzWtLjMECkrlcwiFfCxwNU7MhkOATQ53dxgmNtBa77zw=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.2.1.tgz",
+      "integrity": "sha512-ejAHHbJSRtAhpFVFOQ4niavCDkjISWBxjFQoqznManDZKXBH0vf8EQBWSth5Cp9wXXAG0mAt4gzlwYXEf7Axkg=="
     },
     "node_modules/@pixi/mesh": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.0.2.tgz",
-      "integrity": "sha512-Sc3VrB7/MQ4/Ju86Cks43pJlw6bH0o/SXm/UgIkW7B2cYQMdffcWwt3bOvdyeiChNJWN6308m9VtU0Dx+5xalA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.2.1.tgz",
+      "integrity": "sha512-ekLhRxk6g8sVwrEj3xtVNmyCoCgKSIlqVYL26a2QWYAllWeP1FZiCmBJGk6FAXlIrzG76+aymiUVH35pD1gZvw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.0.2.tgz",
-      "integrity": "sha512-Q2O3/MR5ghMx95N2DnvYbyDL6aK9fU5cxLy6nEAd/i4iNyBA/XIfC7iB6WY207OyF9PIjPedT5Ha1SSSiujhAA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.2.1.tgz",
+      "integrity": "sha512-mgIRiW4W5aOI1lDawNBTNsDZAy+qBGwwBgYsvRqjqOK6cxQ2pnDSEvphK3k2k+Qk2zUBFzqIxSWcG9EWnDQf2Q==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/mesh": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.0.2.tgz",
-      "integrity": "sha512-GBS/s1sf01AWmWBiFD9ppx/20EZMGYvJ2vq/fK/7jmTRA1gTJVI9UA/Suhx3n2KVe7szRDHBAgKKuMjC0W4q7w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.2.1.tgz",
+      "integrity": "sha512-+KsDxCrlvWK2S4ExaKMWFp5RPiFxbBZS2rQ3yrA5GTUC4uZUWm3QptVjHmWb1kjgD5l/QOGF40ZFTu8FfqXtlg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/canvas-renderer": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/sprite": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.0.2.tgz",
-      "integrity": "sha512-qQ+cqOXX50FG3DyuOS69iVc9uOox93ARJoBoh1d3aYwHMUg45oBTyX6xv3suquvPTDcLnKGrJeiHQ/c/xw7tRw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.2.1.tgz",
+      "integrity": "sha512-Osrydgec/Zqu1rxz3wJlNH8qe3a8qyOC6dvzS0QlU6gIe7EUfqFSKSCsnht8zDFTNOBPL/hzG1JKDWTOBqRj8g==",
       "dev": true,
-      "dependencies": {
-        "@pixi/display": "6.0.2"
+      "peerDependencies": {
+        "@pixi/display": "6.2.1"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.0.2.tgz",
-      "integrity": "sha512-waO1D/asjNorJpE+hdJqCg1gnfqOVIUf2mZmKWfS4jW/OPvhbAR1pX6uXP2uZ6yLoK/Ft94x9faMjuDeqxMdFg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.2.1.tgz",
+      "integrity": "sha512-3W5u3b5A4U6glUMPal1/8vug5gs5CIlum9K30VnNQ2Q2bC4mZ6CEBHVIN6pG7ekg3E7xbLwp/WlZM9wZ1yr7ng==",
       "dev": true,
-      "dependencies": {
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2"
+      "peerDependencies": {
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1"
       }
     },
-    "node_modules/@pixi/particles": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-6.0.2.tgz",
-      "integrity": "sha512-Z0vAjqmCGXrdwBmdiC7I4Flv0QQ0q4GxC1lqymT58KhA//GiZOLYp0FuK5RojslLrUu7w5MAfUWwLq7gruu2cQ==",
+    "node_modules/@pixi/particle-container": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.2.1.tgz",
+      "integrity": "sha512-uk8erald8eGiucE0336YTIOS4e1HkSYc8ZYkJnCfxEPcOSMyPEmInI+kWtq0IHa1icX9G4zZRh9rj3vCfCLY+A==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.0.2.tgz",
-      "integrity": "sha512-PD+d3kGPPKoYgkSQ/xT8U3y12T4StkcpCK6QfFy6k+dkWHzGcQI1aE46Vw6tZ+ZkFi5nRUTNk9C3VlwWt/Fdfw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.2.1.tgz",
+      "integrity": "sha512-t7xHLTq3L1FBWT65LR+L1rTjqFq6yDAS+07cG4GCp1TrjcBGV4RGNuB4VhlQOsxVJIhzzEry+3TQt6/EenQ5TQ==",
       "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -912,131 +897,134 @@
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.0.2.tgz",
-      "integrity": "sha512-bmVE/6qV7Psd3EhumLdeAH7MmU3VpuUcnbyDhrmrJrUmfbqrXiMApCLqGSYjMHQI/abZwFQ0vMgDQhx9dfG8wA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.2.1.tgz",
+      "integrity": "sha512-SsNnZilq0gikrO/LjL+gEaUzmrFpkNeROgyfT6Pa3l2HWqG4eoU+iPxSH3f0WshYyZPLF793ryFut9tSJKLCSw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/graphics": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/ticker": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/graphics": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/text": "6.2.1",
+        "@pixi/ticker": "6.2.1"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.0.2.tgz",
-      "integrity": "sha512-HcaDuwT+kconUZJh9gzGy166R/0hWkgXpLX0mqUYo5qPKmhiC+balJsiha6IIV6Ckg5c5IX2GQBSkXJrEDlOMg=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.2.1.tgz",
+      "integrity": "sha512-m3dB5b212WJ3wa7QGBY27NckHtQu1TR2FwtEeMyL0g0tSfCf1ve0Pegf39q9PQ4D1/C1j0n58JuKBqSf9oH66Q=="
     },
     "node_modules/@pixi/settings": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.0.2.tgz",
-      "integrity": "sha512-hZMZIKDsqpf2qtVAnZvemGcFw1ujkZb/r4nVn4/hYeyZLK63I5IpQKEPPK9NMicTM697V+BRoMbWqbrlubiLKw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.2.1.tgz",
+      "integrity": "sha512-GVgLgTdEMZDSEyly+yX+49MhVzEiSyJCHItAurLUVGLvi443AcRuK57mYVNDdTfOn2VRIvwW7FNgwdrzq58WWQ==",
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.0.2.tgz",
-      "integrity": "sha512-I9FHX0zxvfVg/L6hZVRX9kpsdbbxLu9KhN8kdJmDR+RGxuoxGrnboTx5VgT3AW0rYJvwp47VneQTKVVMjat11A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.2.1.tgz",
+      "integrity": "sha512-NV4mS3vUcVgi9qKtY3SH/tf5goinCAJId3bmj76MAlBDNaE8wyu7bEcWLQFIHC59zxJCOd5D/iOmDqVKiOu4Dw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.0.2.tgz",
-      "integrity": "sha512-OSINySJ1uk/iaD4Yk/3czRlitTMVIEgzgvqzSZL+GcqHqzc3lW/BpZ31+so+W/4Yv7KckzBJdB++GvsAfAU0kA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.2.1.tgz",
+      "integrity": "sha512-puJtJFcHgyYuWf4EdFOVMFimtQsTxskNwI/CMw5HQBuz8dPB3aHensVGyv7mPzr0zpl7Ruzb6l+F5Y/G6jbugg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/ticker": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/sprite": "6.2.1",
+        "@pixi/ticker": "6.2.1"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.0.2.tgz",
-      "integrity": "sha512-tauohq//qEZirTM5A6pLKUIUgBPp1qTxjrI4lpFp4scalehAdR04dPe3a9JMr7uwmPiskQIB5/LZX7sMtl3jpg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.2.1.tgz",
+      "integrity": "sha512-YPPqRRBp7JvQq1MjGU7IaKL+7WNeSsHNjUlQfawPR3XvNFLKb7zks1DvR09AziMm8u4h6/wfejFuRycqg/3gvQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/sprite": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.0.2.tgz",
-      "integrity": "sha512-gWVxx0uWKaNtcj1beLZw0vvogDgmerct+oSA0pU6A3b20pDMrAPc90EuOEOOQ/xxxrHfpIY00IIXsUmAmmA0Zg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.2.1.tgz",
+      "integrity": "sha512-mCJn3044/VX2Z0nGr+5brWR2F9akKzKAI4OBqmQU4mfiy7Q4+MM0Fgk9vHc7wKCuhUz//U7SmK6CdCqZknVaAA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/loaders": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.0.2.tgz",
-      "integrity": "sha512-XBhiwLeuL8dBsPwXMDOq9O0JxZcOA2l0aOnFs2O2fZPLL4gkvyquZA+s95C6bGZMR+6j0xtFIQDCsBQCZl1A/g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.2.1.tgz",
+      "integrity": "sha512-vTwXm6RVcSa4RXlqknxf1y7Q35fyOWIlERz3eb6STcoGFOwbXSjdIsAkamjKzbasfF0rSe910QHYxs2XWJ6ozA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/core": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/sprite": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.0.2.tgz",
-      "integrity": "sha512-wT3JUp/Y1+B979UpIMibV3Cir0Tb1oi5Sc1r6FPr51KUfFxHMj6Q7+OV1YxJvSMoaKLK6efImfMXGKAKYtVXMQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.2.1.tgz",
+      "integrity": "sha512-fbOz1aTyXUu0+fuWVnL6eGu5WhpQlF83GM8CKBo2j4NqhxYnkIn4r5g2QSYXVAZ5PSeUjGO0o7lUKxZN0Wq2gg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/utils": "6.0.2"
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/loaders": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/mesh": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/text": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.0.2.tgz",
-      "integrity": "sha512-oBZTfId0D+hDbDCaYvREclI7jvIAmcaxd7iaOPcELHcPPyJ+ym+4hggsXSIchXeeFYasLjI5bfqJPzzL6IasTg==",
-      "dependencies": {
-        "@pixi/settings": "6.0.2"
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.2.1.tgz",
+      "integrity": "sha512-J9UCTIJswM7HO76CtBpJAB+EMBxElmJ+JV9uTUQBGZVc6cmQI9JPPx1QcDWVkuF4qv1Keeh0Tjhnq8Sjc701AA==",
+      "peerDependencies": {
+        "@pixi/settings": "6.2.1"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.0.2.tgz",
-      "integrity": "sha512-jx3ZYJ29mTJSqBPQbDUPPorsPXiGOQzL6IIW5vwE05LekYmwocR8b48vLYKdbr8XdyOQ7Eqe43PodiwCLjuWvA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.2.1.tgz",
+      "integrity": "sha512-aLOIzDZ6ccJ/DfGs9vldjWXn3RHpOMR26Bkr3aeynn/p1rdY3n2dzC8oKWwVb3gPQWmsEZJa8QuLvOiIwHqAJg==",
       "dependencies": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/settings": "6.0.2",
         "@types/earcut": "^2.1.0",
         "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.2.1",
+        "@pixi/settings": "6.2.1"
       }
     },
     "node_modules/@pixi/webdoc-template": {
@@ -3006,9 +2994,9 @@
       "dev": true
     },
     "node_modules/earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "node_modules/ecstatic": {
       "version": "3.3.2",
@@ -6100,11 +6088,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-signals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ="
-    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -7054,14 +7037,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/parse-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.3.tgz",
-      "integrity": "sha512-upMnGxNcm+45So85HoguwZTVZI9u11i36DdxJfGF2HYWS2eh3TIx7+/tTi7qrEq15qzGkVhsKjesau+kCk48pA==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -7189,46 +7164,46 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.0.2.tgz",
-      "integrity": "sha512-ioH2+TxyWMwY+nlOgopxfHBBOpB2Wp79LBNCXPP8dIFWH6q70IAKAL++39aK7+MyLvdqwQ+tSnIWuAMNpKPJCw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.2.1.tgz",
+      "integrity": "sha512-oZaa4QAkzcYnXRBH3O8u2LuUVO6gTPKSZijZIYhv6+EDBULZvPxlOZf7jFQNpXVgKAXhptQmOytO1LnWMuK2Sg==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "6.0.2",
-        "@pixi/app": "6.0.2",
-        "@pixi/compressed-textures": "6.0.2",
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/extract": "6.0.2",
-        "@pixi/filter-alpha": "6.0.2",
-        "@pixi/filter-blur": "6.0.2",
-        "@pixi/filter-color-matrix": "6.0.2",
-        "@pixi/filter-displacement": "6.0.2",
-        "@pixi/filter-fxaa": "6.0.2",
-        "@pixi/filter-noise": "6.0.2",
-        "@pixi/graphics": "6.0.2",
-        "@pixi/interaction": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/mesh-extras": "6.0.2",
-        "@pixi/mixin-cache-as-bitmap": "6.0.2",
-        "@pixi/mixin-get-child-by-name": "6.0.2",
-        "@pixi/mixin-get-global-position": "6.0.2",
-        "@pixi/particles": "6.0.2",
-        "@pixi/polyfill": "6.0.2",
-        "@pixi/prepare": "6.0.2",
-        "@pixi/runner": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/sprite-animated": "6.0.2",
-        "@pixi/sprite-tiling": "6.0.2",
-        "@pixi/spritesheet": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/text-bitmap": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
+        "@pixi/accessibility": "6.2.1",
+        "@pixi/app": "6.2.1",
+        "@pixi/compressed-textures": "6.2.1",
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/extract": "6.2.1",
+        "@pixi/filter-alpha": "6.2.1",
+        "@pixi/filter-blur": "6.2.1",
+        "@pixi/filter-color-matrix": "6.2.1",
+        "@pixi/filter-displacement": "6.2.1",
+        "@pixi/filter-fxaa": "6.2.1",
+        "@pixi/filter-noise": "6.2.1",
+        "@pixi/graphics": "6.2.1",
+        "@pixi/interaction": "6.2.1",
+        "@pixi/loaders": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/mesh": "6.2.1",
+        "@pixi/mesh-extras": "6.2.1",
+        "@pixi/mixin-cache-as-bitmap": "6.2.1",
+        "@pixi/mixin-get-child-by-name": "6.2.1",
+        "@pixi/mixin-get-global-position": "6.2.1",
+        "@pixi/particle-container": "6.2.1",
+        "@pixi/polyfill": "6.2.1",
+        "@pixi/prepare": "6.2.1",
+        "@pixi/runner": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/sprite": "6.2.1",
+        "@pixi/sprite-animated": "6.2.1",
+        "@pixi/sprite-tiling": "6.2.1",
+        "@pixi/spritesheet": "6.2.1",
+        "@pixi/text": "6.2.1",
+        "@pixi/text-bitmap": "6.2.1",
+        "@pixi/ticker": "6.2.1",
+        "@pixi/utils": "6.2.1"
       },
       "funding": {
         "type": "opencollective",
@@ -7498,9 +7473,9 @@
       }
     },
     "node_modules/promise-polyfill": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
-      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
+      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==",
       "dev": true
     },
     "node_modules/proto-list": {
@@ -7558,6 +7533,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -7895,15 +7871,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
-    },
-    "node_modules/resource-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
-      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
-      "dependencies": {
-        "mini-signals": "^1.2.0",
-        "parse-uri": "^1.0.0"
-      }
     },
     "node_modules/responselike": {
       "version": "1.0.2",
@@ -10274,79 +10241,43 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.0.2.tgz",
-      "integrity": "sha512-zHJcrGmpphnqjUQr+5HhcoInuKxZu3PxGl/NRgTC5gpWp259D0LBPT7k3Lt45r4kruDCMUGpMZVb1s46IZniSQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.2.1.tgz",
+      "integrity": "sha512-zXgXx3BostasR69a68BDGVMEjL5CWBct+LtongU1T8HgdXbu2BPaZ/Z679pMj23+5oAR0mUeoH7qTTyRQ2kS3g==",
       "dev": true,
-      "requires": {
-        "@pixi/canvas-renderer": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/app": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.0.2.tgz",
-      "integrity": "sha512-zHCzO0K5jJ48ngbH4FpdYJh1LxuGn9mJSIOF8YorqXFt+3drM9R9/qGGfSGdA9O7rW0O0uIkSndQwPXIlOIsUA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.2.1.tgz",
+      "integrity": "sha512-J1dlu4PTF6O9WfHKTs0pg3NSePW2+8M2yMrivR7R/Z3CmmebnRiquua7U/avQXkLVJBwGdSyij2e6fN8dvnUXw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2"
-      }
-    },
-    "@pixi/canvas-renderer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.0.2.tgz",
-      "integrity": "sha512-SL3pLxAjEQdVN8Tp/p2svciKeA0DRH7HhlO95frVwxzvG4Z3GGYU39f3ejtCaLPqLGzEJmLND7lbIXh0b+Ornw==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/compressed-textures": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.0.2.tgz",
-      "integrity": "sha512-SDuCLn/IEo8j1O+OYPVYy3Dz8+jAXLPdJsMYfs4GOGhsQWZ9js5bfLXWuwr6QRPOXoR3e8zb9qC3co8149pNLg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.2.1.tgz",
+      "integrity": "sha512-ZtmitA5ClIBqBo/dR1pd2n/y/xxOC+UKAj1S04FZiXaekYjmcsPUKxbq2Mgp8Qk2PBdz98HSQ4/xOGAYBMWrdQ==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/loaders": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/constants": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.0.2.tgz",
-      "integrity": "sha512-4GSVKWr+qtjTj8IpRjXSnpkhF944ybjTSz9FnoqZZJgFxh/+9r53StHEGtKoK+BsSrmqbGzWax9krfc620KcLA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.2.1.tgz",
+      "integrity": "sha512-Dppt6rjYP4mIvJCY1I38XhPSfXoOm+A+ERKljLjcvcxVAMhqCTVz3YMp2cUzaio6DtQutiQ6tT06M40xlBZ/lA=="
     },
     "@pixi/core": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.0.2.tgz",
-      "integrity": "sha512-Bz0WQDncrXuLEjU6pX5INrCLd5UorgBfufgysQzncOITIER4sZjAq5R/mCS1M3d4mGFhXZQyMyQK+O4LacWvOQ==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/runner": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-Ndh4/sNXWEkDeU5waWBCsMMPPaQv5uXLyepPXJE0emHBtgJOjKEHa79hrr0p1I2KN7Q8+mw8WlK55yVGuHroIA==",
+      "requires": {}
     },
     "@pixi/display": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.0.2.tgz",
-      "integrity": "sha512-5qJxwT07McA7EK2yFhqvAjEJpap4Xa2hUCRDfsxl+Fu1Y3zDNBKI7HB8+mWZdYtSnnh5fJxrrw5lPo4HX7M+6w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.2.1.tgz",
+      "integrity": "sha512-4taHTgQeAWXrxB4WV0CsyarFEVuI8seKU+12S57c8nQGRYESfDUx4jFatWfgMHY2xCNwCdPTCvlSJzT5ou8VWA==",
       "dev": true,
-      "requires": {
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/eslint-config": {
       "version": "2.0.1",
@@ -10359,193 +10290,125 @@
       }
     },
     "@pixi/extract": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.0.2.tgz",
-      "integrity": "sha512-vGrewyLREzZOGAjcJO60s7oDm8ATbJOB5KyxuJXOSmIuhEmP69ohmxt1Rk6W8nfUS5m3gYU2KsY//RfDghHzVA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.2.1.tgz",
+      "integrity": "sha512-11MTxqXaZlsYRf9QumEDqZXoTb2RlIwpL42k7CnY7ycP+pu8TV+HB5NfLzFltCjnzXuBbl0/bz8eYeU5cSlVkA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/filter-alpha": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.0.2.tgz",
-      "integrity": "sha512-fk7I2mCdQLbt9KrxiCd1103okSoNGXnxa1uY1V66jouSo51IXB3PkNEIFbET/cYOM7kKiMui20sYath1g596ag==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.2.1.tgz",
+      "integrity": "sha512-f/xSY+T9JnpzrtB2F1EOsGr6urgln6Wdr/NQgVk13L/g8jrM/PhMlbDsodEwf5IL/2xRjAFwYjCFMgzWVXALkw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/filter-blur": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.0.2.tgz",
-      "integrity": "sha512-FzaIl4l10lOW4+1SWFjLvK3MtH66zBG1SEa/cMUcVOfwZRIrg5pY3X842kZhNErm42yr9N2xBtKwwVBqQRbV8w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.2.1.tgz",
+      "integrity": "sha512-5pIcdL4u5WAwGHsI8uNovb4iK50l+7Dz1ZIwuwbkGU8Xoti/dzeox4bgywnXPq+yN33/Ty0nwd7VYuHmaNl/Rw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/settings": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/filter-color-matrix": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.0.2.tgz",
-      "integrity": "sha512-zOKdURfQFBIqknpisG1Ow7BiYD7zVTAHU/Y4aPNBFwcAxET/fKFDB8vJFztO1g0C4v05ivjVXmvAuIAjlXdOhw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.2.1.tgz",
+      "integrity": "sha512-f3yyaruhr8lAVv13YpMb5L4yolvuTygq05CvM3OIFK+dP5bYar2cajGc1Zu0bR3VGF03N8JeHxCUwfMwV7V7AA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/filter-displacement": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.0.2.tgz",
-      "integrity": "sha512-ozhpQ0YkGxsMDzE8u/zTYp0LZ52VBM849iCIqY/WSVZkjeNYB0XhUZdI/7RMDPMVfiQSENimacEpsOgzsOIPSA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.2.1.tgz",
+      "integrity": "sha512-o/MjC3tz1y3qZwf22FThGSqfn+zN5bMaBoXn+xSfCqC48thg9vgl2REq0jerDDMVSMW8vUvBUARfT+Wfm3SMDw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/filter-fxaa": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.0.2.tgz",
-      "integrity": "sha512-dkX2udy4CqUuAS5yEu3udzdCbpZVdHgoVEksSiFiGzyC17uexkHaunQAgLb2UFGmjbdLT4Vk2FIrgM3+sMWQ3w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.2.1.tgz",
+      "integrity": "sha512-mIiAhBBDrOOPm1UF4isp7ti3d0y1y0xIZJnYbi15/Stmi1EQsMckDKg+V5uq9qbSm1jP3KoYq9dd7Oz/lr9srw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/filter-noise": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.0.2.tgz",
-      "integrity": "sha512-UnaRYV06qWe7ytBHZ8hK6ZH8Bnqhwtuhoj86pAv0Jhc8EXwcKC2wLT7JDFxBnjB1GwJuWDYnNrQpPsyRQsHNiA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.2.1.tgz",
+      "integrity": "sha512-jDIKo65p1VbqfUKuvb9UaNWaL4SRoc0SMYUwhSJcPjaWKv5bl7Ifqa6b/iQ31ZGHZGSot2ypwFeBiZLG1ndInQ==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/graphics": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.0.2.tgz",
-      "integrity": "sha512-/hONnNsWIo8O/0yQf2voBRi0aLnt7RXHXiYLb1d0bMkfYVHbn6r+TYZsz/mjOC1MRW+B0Bkh5ZxRWOgF3IpCiA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.2.1.tgz",
+      "integrity": "sha512-/MQREXYx+/glVAQLyNTLnd9+C1Bktm/F1XDzu5swDQSRH2Fo1rCh3mPw0dmJmrWrOOpBTO2+W7Kgm6NkENw9qA==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/interaction": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.0.2.tgz",
-      "integrity": "sha512-YRT1reJXISgAf1+lRECpchR7+MUcGA/vdC612oG0fbrONCI0r1jMwMjdEcTnuMzZrzfSGL6yz0pkhIjWMjuY0g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.2.1.tgz",
+      "integrity": "sha512-WsubcDQt447+JtDhDHNfkmkEah4Ytry5WYIKbUZSvBdIc9LVXHPLQ+gM4mKkprEV8ZsQb6H/NbmtIKxjxHGYvw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/loaders": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.0.2.tgz",
-      "integrity": "sha512-ir71du5YOoH/NW8/rNwQ5br+YCVcKWUAltsUaQfTCMLjPzaT8nHtsBiy/krQIGNus179l1h7NfGrSOK/RU936Q==",
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/utils": "6.0.2",
-        "resource-loader": "^3.0.1"
-      }
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.2.1.tgz",
+      "integrity": "sha512-UB1uYb3HL4uN1q+w916DNLIZzz7gkg3p4QQRmBXq08Dnj8DWCghPRAfTGfCu3ORqYqEwSaZ+ulLT+SRfHryvyQ==",
+      "requires": {}
     },
     "@pixi/math": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.0.2.tgz",
-      "integrity": "sha512-eA4VmqkWTUSRl1iYIu3sCitbg8+QfohU0Zk/61J1s0pzWtLjMECkrlcwiFfCxwNU7MhkOATQ53dxgmNtBa77zw=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.2.1.tgz",
+      "integrity": "sha512-ejAHHbJSRtAhpFVFOQ4niavCDkjISWBxjFQoqznManDZKXBH0vf8EQBWSth5Cp9wXXAG0mAt4gzlwYXEf7Axkg=="
     },
     "@pixi/mesh": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.0.2.tgz",
-      "integrity": "sha512-Sc3VrB7/MQ4/Ju86Cks43pJlw6bH0o/SXm/UgIkW7B2cYQMdffcWwt3bOvdyeiChNJWN6308m9VtU0Dx+5xalA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.2.1.tgz",
+      "integrity": "sha512-ekLhRxk6g8sVwrEj3xtVNmyCoCgKSIlqVYL26a2QWYAllWeP1FZiCmBJGk6FAXlIrzG76+aymiUVH35pD1gZvw==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/mesh-extras": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.0.2.tgz",
-      "integrity": "sha512-Q2O3/MR5ghMx95N2DnvYbyDL6aK9fU5cxLy6nEAd/i4iNyBA/XIfC7iB6WY207OyF9PIjPedT5Ha1SSSiujhAA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.2.1.tgz",
+      "integrity": "sha512-mgIRiW4W5aOI1lDawNBTNsDZAy+qBGwwBgYsvRqjqOK6cxQ2pnDSEvphK3k2k+Qk2zUBFzqIxSWcG9EWnDQf2Q==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.0.2.tgz",
-      "integrity": "sha512-GBS/s1sf01AWmWBiFD9ppx/20EZMGYvJ2vq/fK/7jmTRA1gTJVI9UA/Suhx3n2KVe7szRDHBAgKKuMjC0W4q7w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.2.1.tgz",
+      "integrity": "sha512-+KsDxCrlvWK2S4ExaKMWFp5RPiFxbBZS2rQ3yrA5GTUC4uZUWm3QptVjHmWb1kjgD5l/QOGF40ZFTu8FfqXtlg==",
       "dev": true,
-      "requires": {
-        "@pixi/canvas-renderer": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.0.2.tgz",
-      "integrity": "sha512-qQ+cqOXX50FG3DyuOS69iVc9uOox93ARJoBoh1d3aYwHMUg45oBTyX6xv3suquvPTDcLnKGrJeiHQ/c/xw7tRw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.2.1.tgz",
+      "integrity": "sha512-Osrydgec/Zqu1rxz3wJlNH8qe3a8qyOC6dvzS0QlU6gIe7EUfqFSKSCsnht8zDFTNOBPL/hzG1JKDWTOBqRj8g==",
       "dev": true,
-      "requires": {
-        "@pixi/display": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.0.2.tgz",
-      "integrity": "sha512-waO1D/asjNorJpE+hdJqCg1gnfqOVIUf2mZmKWfS4jW/OPvhbAR1pX6uXP2uZ6yLoK/Ft94x9faMjuDeqxMdFg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.2.1.tgz",
+      "integrity": "sha512-3W5u3b5A4U6glUMPal1/8vug5gs5CIlum9K30VnNQ2Q2bC4mZ6CEBHVIN6pG7ekg3E7xbLwp/WlZM9wZ1yr7ng==",
       "dev": true,
-      "requires": {
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2"
-      }
+      "requires": {}
     },
-    "@pixi/particles": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-6.0.2.tgz",
-      "integrity": "sha512-Z0vAjqmCGXrdwBmdiC7I4Flv0QQ0q4GxC1lqymT58KhA//GiZOLYp0FuK5RojslLrUu7w5MAfUWwLq7gruu2cQ==",
+    "@pixi/particle-container": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.2.1.tgz",
+      "integrity": "sha512-uk8erald8eGiucE0336YTIOS4e1HkSYc8ZYkJnCfxEPcOSMyPEmInI+kWtq0IHa1icX9G4zZRh9rj3vCfCLY+A==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/polyfill": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.0.2.tgz",
-      "integrity": "sha512-PD+d3kGPPKoYgkSQ/xT8U3y12T4StkcpCK6QfFy6k+dkWHzGcQI1aE46Vw6tZ+ZkFi5nRUTNk9C3VlwWt/Fdfw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.2.1.tgz",
+      "integrity": "sha512-t7xHLTq3L1FBWT65LR+L1rTjqFq6yDAS+07cG4GCp1TrjcBGV4RGNuB4VhlQOsxVJIhzzEry+3TQt6/EenQ5TQ==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -10553,127 +10416,78 @@
       }
     },
     "@pixi/prepare": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.0.2.tgz",
-      "integrity": "sha512-bmVE/6qV7Psd3EhumLdeAH7MmU3VpuUcnbyDhrmrJrUmfbqrXiMApCLqGSYjMHQI/abZwFQ0vMgDQhx9dfG8wA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.2.1.tgz",
+      "integrity": "sha512-SsNnZilq0gikrO/LjL+gEaUzmrFpkNeROgyfT6Pa3l2HWqG4eoU+iPxSH3f0WshYyZPLF793ryFut9tSJKLCSw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/graphics": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/ticker": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/runner": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.0.2.tgz",
-      "integrity": "sha512-HcaDuwT+kconUZJh9gzGy166R/0hWkgXpLX0mqUYo5qPKmhiC+balJsiha6IIV6Ckg5c5IX2GQBSkXJrEDlOMg=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.2.1.tgz",
+      "integrity": "sha512-m3dB5b212WJ3wa7QGBY27NckHtQu1TR2FwtEeMyL0g0tSfCf1ve0Pegf39q9PQ4D1/C1j0n58JuKBqSf9oH66Q=="
     },
     "@pixi/settings": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.0.2.tgz",
-      "integrity": "sha512-hZMZIKDsqpf2qtVAnZvemGcFw1ujkZb/r4nVn4/hYeyZLK63I5IpQKEPPK9NMicTM697V+BRoMbWqbrlubiLKw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.2.1.tgz",
+      "integrity": "sha512-GVgLgTdEMZDSEyly+yX+49MhVzEiSyJCHItAurLUVGLvi443AcRuK57mYVNDdTfOn2VRIvwW7FNgwdrzq58WWQ==",
       "requires": {
         "ismobilejs": "^1.1.0"
       }
     },
     "@pixi/sprite": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.0.2.tgz",
-      "integrity": "sha512-I9FHX0zxvfVg/L6hZVRX9kpsdbbxLu9KhN8kdJmDR+RGxuoxGrnboTx5VgT3AW0rYJvwp47VneQTKVVMjat11A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.2.1.tgz",
+      "integrity": "sha512-NV4mS3vUcVgi9qKtY3SH/tf5goinCAJId3bmj76MAlBDNaE8wyu7bEcWLQFIHC59zxJCOd5D/iOmDqVKiOu4Dw==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/sprite-animated": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.0.2.tgz",
-      "integrity": "sha512-OSINySJ1uk/iaD4Yk/3czRlitTMVIEgzgvqzSZL+GcqHqzc3lW/BpZ31+so+W/4Yv7KckzBJdB++GvsAfAU0kA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.2.1.tgz",
+      "integrity": "sha512-puJtJFcHgyYuWf4EdFOVMFimtQsTxskNwI/CMw5HQBuz8dPB3aHensVGyv7mPzr0zpl7Ruzb6l+F5Y/G6jbugg==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/ticker": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/sprite-tiling": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.0.2.tgz",
-      "integrity": "sha512-tauohq//qEZirTM5A6pLKUIUgBPp1qTxjrI4lpFp4scalehAdR04dPe3a9JMr7uwmPiskQIB5/LZX7sMtl3jpg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.2.1.tgz",
+      "integrity": "sha512-YPPqRRBp7JvQq1MjGU7IaKL+7WNeSsHNjUlQfawPR3XvNFLKb7zks1DvR09AziMm8u4h6/wfejFuRycqg/3gvQ==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/spritesheet": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.0.2.tgz",
-      "integrity": "sha512-gWVxx0uWKaNtcj1beLZw0vvogDgmerct+oSA0pU6A3b20pDMrAPc90EuOEOOQ/xxxrHfpIY00IIXsUmAmmA0Zg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.2.1.tgz",
+      "integrity": "sha512-mCJn3044/VX2Z0nGr+5brWR2F9akKzKAI4OBqmQU4mfiy7Q4+MM0Fgk9vHc7wKCuhUz//U7SmK6CdCqZknVaAA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/text": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.0.2.tgz",
-      "integrity": "sha512-XBhiwLeuL8dBsPwXMDOq9O0JxZcOA2l0aOnFs2O2fZPLL4gkvyquZA+s95C6bGZMR+6j0xtFIQDCsBQCZl1A/g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.2.1.tgz",
+      "integrity": "sha512-vTwXm6RVcSa4RXlqknxf1y7Q35fyOWIlERz3eb6STcoGFOwbXSjdIsAkamjKzbasfF0rSe910QHYxs2XWJ6ozA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/text-bitmap": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.0.2.tgz",
-      "integrity": "sha512-wT3JUp/Y1+B979UpIMibV3Cir0Tb1oi5Sc1r6FPr51KUfFxHMj6Q7+OV1YxJvSMoaKLK6efImfMXGKAKYtVXMQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.2.1.tgz",
+      "integrity": "sha512-fbOz1aTyXUu0+fuWVnL6eGu5WhpQlF83GM8CKBo2j4NqhxYnkIn4r5g2QSYXVAZ5PSeUjGO0o7lUKxZN0Wq2gg==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/utils": "6.0.2"
-      }
+      "requires": {}
     },
     "@pixi/ticker": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.0.2.tgz",
-      "integrity": "sha512-oBZTfId0D+hDbDCaYvREclI7jvIAmcaxd7iaOPcELHcPPyJ+ym+4hggsXSIchXeeFYasLjI5bfqJPzzL6IasTg==",
-      "requires": {
-        "@pixi/settings": "6.0.2"
-      }
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.2.1.tgz",
+      "integrity": "sha512-J9UCTIJswM7HO76CtBpJAB+EMBxElmJ+JV9uTUQBGZVc6cmQI9JPPx1QcDWVkuF4qv1Keeh0Tjhnq8Sjc701AA==",
+      "requires": {}
     },
     "@pixi/utils": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.0.2.tgz",
-      "integrity": "sha512-jx3ZYJ29mTJSqBPQbDUPPorsPXiGOQzL6IIW5vwE05LekYmwocR8b48vLYKdbr8XdyOQ7Eqe43PodiwCLjuWvA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.2.1.tgz",
+      "integrity": "sha512-aLOIzDZ6ccJ/DfGs9vldjWXn3RHpOMR26Bkr3aeynn/p1rdY3n2dzC8oKWwVb3gPQWmsEZJa8QuLvOiIwHqAJg==",
       "requires": {
-        "@pixi/constants": "6.0.2",
-        "@pixi/settings": "6.0.2",
         "@types/earcut": "^2.1.0",
         "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
@@ -12258,9 +12072,9 @@
       "dev": true
     },
     "earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "ecstatic": {
       "version": "3.3.2",
@@ -14664,11 +14478,6 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
-    "mini-signals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -15406,11 +15215,6 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
-    "parse-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.3.tgz",
-      "integrity": "sha512-upMnGxNcm+45So85HoguwZTVZI9u11i36DdxJfGF2HYWS2eh3TIx7+/tTi7qrEq15qzGkVhsKjesau+kCk48pA=="
-    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -15499,46 +15303,46 @@
       }
     },
     "pixi.js": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.0.2.tgz",
-      "integrity": "sha512-ioH2+TxyWMwY+nlOgopxfHBBOpB2Wp79LBNCXPP8dIFWH6q70IAKAL++39aK7+MyLvdqwQ+tSnIWuAMNpKPJCw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.2.1.tgz",
+      "integrity": "sha512-oZaa4QAkzcYnXRBH3O8u2LuUVO6gTPKSZijZIYhv6+EDBULZvPxlOZf7jFQNpXVgKAXhptQmOytO1LnWMuK2Sg==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "6.0.2",
-        "@pixi/app": "6.0.2",
-        "@pixi/compressed-textures": "6.0.2",
-        "@pixi/constants": "6.0.2",
-        "@pixi/core": "6.0.2",
-        "@pixi/display": "6.0.2",
-        "@pixi/extract": "6.0.2",
-        "@pixi/filter-alpha": "6.0.2",
-        "@pixi/filter-blur": "6.0.2",
-        "@pixi/filter-color-matrix": "6.0.2",
-        "@pixi/filter-displacement": "6.0.2",
-        "@pixi/filter-fxaa": "6.0.2",
-        "@pixi/filter-noise": "6.0.2",
-        "@pixi/graphics": "6.0.2",
-        "@pixi/interaction": "6.0.2",
-        "@pixi/loaders": "6.0.2",
-        "@pixi/math": "6.0.2",
-        "@pixi/mesh": "6.0.2",
-        "@pixi/mesh-extras": "6.0.2",
-        "@pixi/mixin-cache-as-bitmap": "6.0.2",
-        "@pixi/mixin-get-child-by-name": "6.0.2",
-        "@pixi/mixin-get-global-position": "6.0.2",
-        "@pixi/particles": "6.0.2",
-        "@pixi/polyfill": "6.0.2",
-        "@pixi/prepare": "6.0.2",
-        "@pixi/runner": "6.0.2",
-        "@pixi/settings": "6.0.2",
-        "@pixi/sprite": "6.0.2",
-        "@pixi/sprite-animated": "6.0.2",
-        "@pixi/sprite-tiling": "6.0.2",
-        "@pixi/spritesheet": "6.0.2",
-        "@pixi/text": "6.0.2",
-        "@pixi/text-bitmap": "6.0.2",
-        "@pixi/ticker": "6.0.2",
-        "@pixi/utils": "6.0.2"
+        "@pixi/accessibility": "6.2.1",
+        "@pixi/app": "6.2.1",
+        "@pixi/compressed-textures": "6.2.1",
+        "@pixi/constants": "6.2.1",
+        "@pixi/core": "6.2.1",
+        "@pixi/display": "6.2.1",
+        "@pixi/extract": "6.2.1",
+        "@pixi/filter-alpha": "6.2.1",
+        "@pixi/filter-blur": "6.2.1",
+        "@pixi/filter-color-matrix": "6.2.1",
+        "@pixi/filter-displacement": "6.2.1",
+        "@pixi/filter-fxaa": "6.2.1",
+        "@pixi/filter-noise": "6.2.1",
+        "@pixi/graphics": "6.2.1",
+        "@pixi/interaction": "6.2.1",
+        "@pixi/loaders": "6.2.1",
+        "@pixi/math": "6.2.1",
+        "@pixi/mesh": "6.2.1",
+        "@pixi/mesh-extras": "6.2.1",
+        "@pixi/mixin-cache-as-bitmap": "6.2.1",
+        "@pixi/mixin-get-child-by-name": "6.2.1",
+        "@pixi/mixin-get-global-position": "6.2.1",
+        "@pixi/particle-container": "6.2.1",
+        "@pixi/polyfill": "6.2.1",
+        "@pixi/prepare": "6.2.1",
+        "@pixi/runner": "6.2.1",
+        "@pixi/settings": "6.2.1",
+        "@pixi/sprite": "6.2.1",
+        "@pixi/sprite-animated": "6.2.1",
+        "@pixi/sprite-tiling": "6.2.1",
+        "@pixi/spritesheet": "6.2.1",
+        "@pixi/text": "6.2.1",
+        "@pixi/text-bitmap": "6.2.1",
+        "@pixi/ticker": "6.2.1",
+        "@pixi/utils": "6.2.1"
       }
     },
     "pkg-dir": {
@@ -15751,9 +15555,9 @@
       "dev": true
     },
     "promise-polyfill": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
-      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
+      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==",
       "dev": true
     },
     "proto-list": {
@@ -16055,15 +15859,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
-    },
-    "resource-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
-      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
-      "requires": {
-        "mini-signals": "^1.2.0",
-        "parse-uri": "^1.0.0"
-      }
     },
     "responselike": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -7,16 +7,18 @@
   "types": "dist/pixi-sound.d.ts",
   "scripts": {
     "test": "floss -p test --require ts-node/register -- --autoplay-policy=no-user-gesture-required",
+    "test:debug": "floss -p test --debug --require ts-node/register -- --autoplay-policy=no-user-gesture-required",
     "coverage": "nyc floss -p test --require ts-node/register -- --autoplay-policy=no-user-gesture-required",
     "clean": "rimraf dist/**",
     "start": "run-s watch",
     "watch": "rollup -c  config/rollup.js --environment DEV --watch",
-    "lint": "eslint --ext .js --ext .ts test src examples/client --ignore-path .gitignore",
+    "lint": "eslint --ext .js --ext .ts test scripts src examples/client --ignore-path .gitignore",
     "lint:fix": "npm run lint -- --fix",
     "types": "tsc -p tsconfig.json --noEmit",
     "prebuild": "run-s clean lint types",
     "build": "rollup -c config/rollup.js",
-    "postbuild": "run-s build:types bundle:types",
+    "postbuild": "run-s build:types bundle:types fix:types",
+    "fix:types": "ts-node scripts/injectGlobalMixins.ts",
     "build:prod": "cross-env NODE_ENV=production run-s build",
     "prebuild:types": "rimraf .types_output/**",
     "build:types": "tsc --declaration --emitDeclarationOnly --skipLibCheck --outDir .types_output",
@@ -50,7 +52,7 @@
   },
   "files": [
     "dist/",
-    "pixi-sound.d.ts"
+    "global.d.ts"
   ],
   "keywords": [
     "webaudio",
@@ -100,7 +102,7 @@
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.0",
-    "pixi.js": "^6.0.0",
+    "pixi.js": "^6.2.1",
     "pre-commit": "^1.2.2",
     "rimraf": "^2.6.3",
     "rollup": "^2.0.0",

--- a/scripts/injectGlobalMixins.ts
+++ b/scripts/injectGlobalMixins.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+import fs from 'fs';
+import pkg from '../package.json';
+
+async function main(): Promise<void>
+{
+    const { types } = pkg;
+    const typesPath = path.resolve(path.dirname(__dirname), types);
+    const buffer = await fs.promises.readFile(typesPath, 'utf-8');
+    const inject = `/// <reference path="../global.d.ts" />\n`;
+
+    if (!buffer.includes(inject))
+    {
+        await fs.promises.writeFile(typesPath, inject + buffer);
+        // eslint-disable-next-line no-console
+        console.log('Types patched with GlobalMixins.');
+    }
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
+    "ts-node": {
+        "transpileOnly": true,
+        "compilerOptions": {
+            "resolveJsonModule": true
+        }
+    },
     "compilerOptions": {
         "moduleResolution": "node",
         "target": "es5",


### PR DESCRIPTION
In PixiJS 6.1+ mixin typings for LoaderResource is support. This allows proper typings when referencing the LoaderResource object directly from the Loader. E.g.:

```ts
import { Loader } from 'pixi.js';
import '@pixi/sound';

const loader = new Loader();
loader.add('myMusic', 'myMusic.mp3');
loader.load((ldr, resources) => {
    resources.myMusic.sound // <-- `sound` typed as Sound object
});