### PR TITLE
Remove workaround for namespace exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "4.1.1",
       "license": "MIT",
       "devDependencies": {
-        "@microsoft/api-extractor": "^7.13.3",
+        "@microsoft/api-extractor": "^7.19.3",
         "@pixi/eslint-config": "^2.0.2",
         "@pixi/webdoc-template": "^1.5.3",
         "@rollup/plugin-typescript": "^8.0.0",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "@types/node": "^12.0.0",
+        "@types/offscreencanvas": "^2019.6.4",
         "@webdoc/cli": "^1.5.5",
         "chai": "^4.2.0",
         "clean-package": "^1.0.1",
@@ -667,55 +668,69 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.13.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.13.3.tgz",
-      "integrity": "sha512-hk40nqOk8QYs70SH5vAhTdPYrMUNm4ASNiPFoV9YiFGeiHkC0Ll5IvTtIhs3l2EjnaEjAJuZMgczT4ZlwB/CSQ==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.19.3.tgz",
+      "integrity": "sha512-GZe+R3K4kh2X425iOHkPbByysB7FN0592mPPA6vNj5IhyhlPHgdZS6m6AmOZOIxMS4euM+SBKzEJEp3oC+WsOQ==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.12.3",
-        "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.1",
-        "@rushstack/rig-package": "0.2.11",
-        "@rushstack/ts-command-line": "4.7.9",
+        "@microsoft/api-extractor-model": "7.15.2",
+        "@microsoft/tsdoc": "0.13.2",
+        "@microsoft/tsdoc-config": "~0.15.2",
+        "@rushstack/node-core-library": "3.44.3",
+        "@rushstack/rig-package": "0.3.7",
+        "@rushstack/ts-command-line": "4.10.6",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
-        "typescript": "~4.1.3"
+        "typescript": "~4.5.2"
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.12.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.12.3.tgz",
-      "integrity": "sha512-lLy1UDJOkk7nuhSdAqjlULSd/yWNrSqDnUduwPwtmUoOX3QIfeDhlV5bKmq5Tw6RBq3ydgjasThyxfj1Og15MA==",
+      "version": "7.15.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.15.2.tgz",
+      "integrity": "sha512-qgxKX/s6vo3nCVLhP0Ds7555QrErhcYHEok5/KyEZ7iR8J5M5oldD1eJJQmtEdVF5IzmnPPbxx1nRvfgA674LQ==",
       "dev": true,
       "dependencies": {
-        "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.1"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "@microsoft/tsdoc": "0.13.2",
+        "@microsoft/tsdoc-config": "~0.15.2",
+        "@rushstack/node-core-library": "3.44.3"
       }
     },
     "node_modules/@microsoft/tsdoc": {
-      "version": "0.12.24",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.24.tgz",
-      "integrity": "sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
+      "integrity": "sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==",
       "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz",
+      "integrity": "sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.13.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -1220,12 +1235,12 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.36.1.tgz",
-      "integrity": "sha512-YMXJ0bEpxG9AnK1shZTOay5xSIuerzxCV9sscn3xynnndBdma0oE243V79Fb25zzLfkZ1Xg9TbOXc5zmF7NYYA==",
+      "version": "3.44.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.44.3.tgz",
+      "integrity": "sha512-Bt+R5LAnVr2BImTJqPpton5rvhJ2Wq8x4BaTqaCHQMmfxqtz5lb4nLYT9kneMJTCDuRMBvvLpSuz4MBj50PV3w==",
       "dev": true,
       "dependencies": {
-        "@types/node": "10.17.13",
+        "@types/node": "12.20.24",
         "colors": "~1.2.1",
         "fs-extra": "~7.0.1",
         "import-lazy": "~4.0.0",
@@ -1233,14 +1248,8 @@
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "timsort": "~0.3.0",
-        "z-schema": "~3.18.3"
+        "z-schema": "~5.0.2"
       }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/@types/node": {
-      "version": "10.17.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-      "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
-      "dev": true
     },
     "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
       "version": "7.0.1",
@@ -1275,9 +1284,9 @@
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.11.tgz",
-      "integrity": "sha512-6Q07ZxjnthXWSXfDy/CgjhhGaqb/0RvZbqWScLr216Cy7fuAAmjbMhE2E53+rjXOsolrS5Ep7Xcl5TQre723cA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.7.tgz",
+      "integrity": "sha512-pzMsTSeTC8IiZ6EJLr53gGMvhT4oLWH+hxD7907cHyWuIUlEXFtu/2pK25vUQT13nKp5DJCWxXyYoGRk/h6rtA==",
       "dev": true,
       "dependencies": {
         "resolve": "~1.17.0",
@@ -1285,9 +1294,9 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.9.tgz",
-      "integrity": "sha512-Jq5O4t0op9xdFfS9RbUV/ZFlAFxX6gdVTY+69UFRTn9pwWOzJR0kroty01IlnDByPCgvHH8RMz9sEXzD9Qxdrg==",
+      "version": "4.10.6",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.10.6.tgz",
+      "integrity": "sha512-Y3GkUag39sTIlukDg9mUp8MCHrrlJ27POrBNRQGc/uF+VVgX8M7zMzHch5zP6O1QVquWgD7Engdpn2piPYaS/g==",
       "dev": true,
       "dependencies": {
         "@types/argparse": "1.0.38",
@@ -1353,15 +1362,21 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==",
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.6.4",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -9232,9 +9247,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -9462,9 +9477,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -9767,17 +9782,20 @@
       }
     },
     "node_modules/z-schema": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
-      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.2.tgz",
+      "integrity": "sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==",
       "dev": true,
       "dependencies": {
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^8.0.0"
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
       },
       "bin": {
         "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       },
       "optionalDependencies": {
         "commander": "^2.7.1"
@@ -10267,47 +10285,65 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.13.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.13.3.tgz",
-      "integrity": "sha512-hk40nqOk8QYs70SH5vAhTdPYrMUNm4ASNiPFoV9YiFGeiHkC0Ll5IvTtIhs3l2EjnaEjAJuZMgczT4ZlwB/CSQ==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.19.3.tgz",
+      "integrity": "sha512-GZe+R3K4kh2X425iOHkPbByysB7FN0592mPPA6vNj5IhyhlPHgdZS6m6AmOZOIxMS4euM+SBKzEJEp3oC+WsOQ==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.12.3",
-        "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.1",
-        "@rushstack/rig-package": "0.2.11",
-        "@rushstack/ts-command-line": "4.7.9",
+        "@microsoft/api-extractor-model": "7.15.2",
+        "@microsoft/tsdoc": "0.13.2",
+        "@microsoft/tsdoc-config": "~0.15.2",
+        "@rushstack/node-core-library": "3.44.3",
+        "@rushstack/rig-package": "0.3.7",
+        "@rushstack/ts-command-line": "4.10.6",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
-        "typescript": "~4.1.3"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
-          "dev": true
-        }
+        "typescript": "~4.5.2"
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.12.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.12.3.tgz",
-      "integrity": "sha512-lLy1UDJOkk7nuhSdAqjlULSd/yWNrSqDnUduwPwtmUoOX3QIfeDhlV5bKmq5Tw6RBq3ydgjasThyxfj1Og15MA==",
+      "version": "7.15.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.15.2.tgz",
+      "integrity": "sha512-qgxKX/s6vo3nCVLhP0Ds7555QrErhcYHEok5/KyEZ7iR8J5M5oldD1eJJQmtEdVF5IzmnPPbxx1nRvfgA674LQ==",
       "dev": true,
       "requires": {
-        "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.1"
+        "@microsoft/tsdoc": "0.13.2",
+        "@microsoft/tsdoc-config": "~0.15.2",
+        "@rushstack/node-core-library": "3.44.3"
       }
     },
     "@microsoft/tsdoc": {
-      "version": "0.12.24",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.24.tgz",
-      "integrity": "sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
+      "integrity": "sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==",
       "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz",
+      "integrity": "sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.13.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -10630,12 +10666,12 @@
       }
     },
     "@rushstack/node-core-library": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.36.1.tgz",
-      "integrity": "sha512-YMXJ0bEpxG9AnK1shZTOay5xSIuerzxCV9sscn3xynnndBdma0oE243V79Fb25zzLfkZ1Xg9TbOXc5zmF7NYYA==",
+      "version": "3.44.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.44.3.tgz",
+      "integrity": "sha512-Bt+R5LAnVr2BImTJqPpton5rvhJ2Wq8x4BaTqaCHQMmfxqtz5lb4nLYT9kneMJTCDuRMBvvLpSuz4MBj50PV3w==",
       "dev": true,
       "requires": {
-        "@types/node": "10.17.13",
+        "@types/node": "12.20.24",
         "colors": "~1.2.1",
         "fs-extra": "~7.0.1",
         "import-lazy": "~4.0.0",
@@ -10643,15 +10679,9 @@
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "timsort": "~0.3.0",
-        "z-schema": "~3.18.3"
+        "z-schema": "~5.0.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -10681,9 +10711,9 @@
       }
     },
     "@rushstack/rig-package": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.11.tgz",
-      "integrity": "sha512-6Q07ZxjnthXWSXfDy/CgjhhGaqb/0RvZbqWScLr216Cy7fuAAmjbMhE2E53+rjXOsolrS5Ep7Xcl5TQre723cA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.7.tgz",
+      "integrity": "sha512-pzMsTSeTC8IiZ6EJLr53gGMvhT4oLWH+hxD7907cHyWuIUlEXFtu/2pK25vUQT13nKp5DJCWxXyYoGRk/h6rtA==",
       "dev": true,
       "requires": {
         "resolve": "~1.17.0",
@@ -10691,9 +10721,9 @@
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.9.tgz",
-      "integrity": "sha512-Jq5O4t0op9xdFfS9RbUV/ZFlAFxX6gdVTY+69UFRTn9pwWOzJR0kroty01IlnDByPCgvHH8RMz9sEXzD9Qxdrg==",
+      "version": "4.10.6",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.10.6.tgz",
+      "integrity": "sha512-Y3GkUag39sTIlukDg9mUp8MCHrrlJ27POrBNRQGc/uF+VVgX8M7zMzHch5zP6O1QVquWgD7Engdpn2piPYaS/g==",
       "dev": true,
       "requires": {
         "@types/argparse": "1.0.38",
@@ -10753,15 +10783,21 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==",
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/offscreencanvas": {
+      "version": "2019.6.4",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -16905,9 +16941,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uc.micro": {
@@ -17096,9 +17132,9 @@
       }
     },
     "validator": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true
     },
     "webidl-conversions": {
@@ -17339,15 +17375,15 @@
       "dev": true
     },
     "z-schema": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
-      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.2.tgz",
+      "integrity": "sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==",
       "dev": true,
       "requires": {
         "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^8.0.0"
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -81,13 +81,14 @@
     ]
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.13.3",
+    "@microsoft/api-extractor": "^7.19.3",
     "@pixi/eslint-config": "^2.0.2",
     "@pixi/webdoc-template": "^1.5.3",
     "@rollup/plugin-typescript": "^8.0.0",
     "@types/chai": "^4.2.16",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.0.0",
+    "@types/offscreencanvas": "^2019.6.4",
     "@webdoc/cli": "^1.5.5",
     "chai": "^4.2.0",
     "clean-package": "^1.0.1",

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -1,12 +1,3 @@
-import { Filter } from './Filter';
-import { EqualizerFilter } from './EqualizerFilter';
-import { DistortionFilter } from './DistortionFilter';
-import { StereoFilter } from './StereoFilter';
-import { ReverbFilter } from './ReverbFilter';
-import { MonoFilter } from './MonoFilter';
-import { StreamFilter } from './StreamFilter';
-import { TelephoneFilter } from './TelephoneFilter';
-
 /**
  * Set of dynamic filters to be applied to Sound.
  * @example
@@ -18,13 +9,11 @@ import { TelephoneFilter } from './TelephoneFilter';
  * ];
  * @namespace filters
  */
-export default {
-    Filter,
-    EqualizerFilter,
-    DistortionFilter,
-    StereoFilter,
-    ReverbFilter,
-    MonoFilter,
-    StreamFilter,
-    TelephoneFilter
-};
+export { Filter } from './Filter';
+export { EqualizerFilter } from './EqualizerFilter';
+export { DistortionFilter } from './DistortionFilter';
+export { StereoFilter } from './StereoFilter';
+export { ReverbFilter } from './ReverbFilter';
+export { MonoFilter } from './MonoFilter';
+export { StreamFilter } from './StreamFilter';
+export { TelephoneFilter } from './TelephoneFilter';

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -9,11 +9,11 @@
  * ];
  * @namespace filters
  */
-export { Filter } from './Filter';
-export { EqualizerFilter } from './EqualizerFilter';
-export { DistortionFilter } from './DistortionFilter';
-export { StereoFilter } from './StereoFilter';
-export { ReverbFilter } from './ReverbFilter';
-export { MonoFilter } from './MonoFilter';
-export { StreamFilter } from './StreamFilter';
-export { TelephoneFilter } from './TelephoneFilter';
+export * from './Filter';
+export * from './EqualizerFilter';
+export * from './DistortionFilter';
+export * from './StereoFilter';
+export * from './ReverbFilter';
+export * from './MonoFilter';
+export * from './StreamFilter';
+export * from './TelephoneFilter';

--- a/src/htmlaudio/index.ts
+++ b/src/htmlaudio/index.ts
@@ -1,13 +1,7 @@
-import { HTMLAudioMedia } from './HTMLAudioMedia';
-import { HTMLAudioInstance } from './HTMLAudioInstance';
-import { HTMLAudioContext } from './HTMLAudioContext';
-
 /**
  * Classes supporting non-WebAudio based browsers.
  * @namespace htmlaudio
  */
-export default {
-    HTMLAudioContext,
-    HTMLAudioMedia,
-    HTMLAudioInstance,
-};
+export { HTMLAudioMedia } from './HTMLAudioMedia';
+export { HTMLAudioInstance } from './HTMLAudioInstance';
+export { HTMLAudioContext } from './HTMLAudioContext';

--- a/src/htmlaudio/index.ts
+++ b/src/htmlaudio/index.ts
@@ -2,6 +2,6 @@
  * Classes supporting non-WebAudio based browsers.
  * @namespace htmlaudio
  */
-export { HTMLAudioMedia } from './HTMLAudioMedia';
-export { HTMLAudioInstance } from './HTMLAudioInstance';
-export { HTMLAudioContext } from './HTMLAudioContext';
+export * from './HTMLAudioMedia';
+export * from './HTMLAudioInstance';
+export * from './HTMLAudioContext';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@ import { Loader } from '@pixi/loaders';
 import { setInstance } from './instance';
 import { SoundLoader } from './SoundLoader';
 import { SoundLibrary } from './SoundLibrary';
-import htmlaudio from './htmlaudio';
-import filters from './filters';
-import webaudio from './webaudio';
-import utils from './utils';
+import * as htmlaudio from './htmlaudio';
+import * as filters from './filters';
+import * as webaudio from './webaudio';
+import * as utils from './utils';
 
 const sound = setInstance(new SoundLibrary());
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,8 +2,8 @@
  * Utilities that work with sounds.
  * @namespace utils
  */
-export { playOnce } from './playOnce';
-export { render } from './render';
-export { resolveUrl } from './resolveUrl';
-export { sineTone } from './sineTone';
-export { supported, extensions, validateFormats } from './supported';
+export * from './playOnce';
+export * from './render';
+export * from './resolveUrl';
+export * from './sineTone';
+export * from './supported';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,19 +1,9 @@
-import { playOnce } from './playOnce';
-import { render } from './render';
-import { resolveUrl } from './resolveUrl';
-import { sineTone } from './sineTone';
-import { supported, extensions, validateFormats } from './supported';
-
 /**
  * Utilities that work with sounds.
  * @namespace utils
  */
-export default {
-    playOnce,
-    render,
-    resolveUrl,
-    sineTone,
-    supported,
-    extensions,
-    validateFormats
-};
+export { playOnce } from './playOnce';
+export { render } from './render';
+export { resolveUrl } from './resolveUrl';
+export { sineTone } from './sineTone';
+export { supported, extensions, validateFormats } from './supported';

--- a/src/webaudio/index.ts
+++ b/src/webaudio/index.ts
@@ -1,17 +1,9 @@
-import { WebAudioMedia } from './WebAudioMedia';
-import { WebAudioInstance } from './WebAudioInstance';
-import { WebAudioNodes } from './WebAudioNodes';
-import { WebAudioContext } from './WebAudioContext';
-import { WebAudioUtils } from './WebAudioUtils';
-
 /**
  * Classes supporting non-WebAudio based browsers.
  * @namespace webaudio
  */
-export default {
-    WebAudioMedia,
-    WebAudioInstance,
-    WebAudioNodes,
-    WebAudioContext,
-    WebAudioUtils
-};
+export { WebAudioMedia } from './WebAudioMedia';
+export { WebAudioInstance } from './WebAudioInstance';
+export { WebAudioNodes } from './WebAudioNodes';
+export { WebAudioContext } from './WebAudioContext';
+export { WebAudioUtils } from './WebAudioUtils';

--- a/src/webaudio/index.ts
+++ b/src/webaudio/index.ts
@@ -2,8 +2,8 @@
  * Classes supporting non-WebAudio based browsers.
  * @namespace webaudio
  */
-export { WebAudioMedia } from './WebAudioMedia';
-export { WebAudioInstance } from './WebAudioInstance';
-export { WebAudioNodes } from './WebAudioNodes';
-export { WebAudioContext } from './WebAudioContext';
-export { WebAudioUtils } from './WebAudioUtils';
+export * from './WebAudioMedia';
+export * from './WebAudioInstance';
+export * from './WebAudioNodes';
+export * from './WebAudioContext';
+export * from './WebAudioUtils';


### PR DESCRIPTION
### Changes

* Upgraded API Extractor to support exporting namespaces (`import * as ns from './file'`) this previously wasn't possible and required a bunch of ugly workarounds. Those have been removed.