### PR TITLE
Fix Uncaught DOMException in Firefox

### DIFF
--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -77,8 +77,7 @@ class WebAudioContext extends Filterable implements IMediaContext
         this._ctx = ctx;
         // ios11 safari's webkitOfflineAudioContext allows only 44100 Hz sample rate
         this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2,
-            ((win.OfflineAudioContext) && (8000 <= ctx.sampleRate && ctx.sampleRate <= 96000))
-            ? ctx.sampleRate : 44100);
+            ((win.OfflineAudioContext) && (ctx.sampleRate >= 8000 && ctx.sampleRate <= 96000)) ? ctx.sampleRate : 44100);
         this._unlocked = false;
 
         this.compressor = compressor;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -79,7 +79,8 @@ class WebAudioContext extends Filterable implements IMediaContext
         //
         // For the sample rate value passed to OfflineAudioContext constructor,
         // all browsers are required to support a range of 8000 to 96000.
-        // Reference: https://www.w3.org/TR/webaudio/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate
+        // Reference:
+        // https://www.w3.org/TR/webaudio/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate
         this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2,
             (win.OfflineAudioContext) ? Math.max(8000, Math.min(96000, ctx.sampleRate)) : 44100);
         this._unlocked = false;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -76,6 +76,10 @@ class WebAudioContext extends Filterable implements IMediaContext
 
         this._ctx = ctx;
         // ios11 safari's webkitOfflineAudioContext allows only 44100 Hz sample rate
+        //
+        // For the sample rate value passed to OfflineAudioContext constructor,
+        // all browsers are required to support a range of 8000 to 96000.
+        // Reference: https://www.w3.org/TR/webaudio/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate
         this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2,
             (win.OfflineAudioContext) ? Math.max(8000, Math.min(96000, ctx.sampleRate)) : 44100);
         this._unlocked = false;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -77,7 +77,7 @@ class WebAudioContext extends Filterable implements IMediaContext
         this._ctx = ctx;
         // ios11 safari's webkitOfflineAudioContext allows only 44100 Hz sample rate
         this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2,
-            ((win.OfflineAudioContext) && (ctx.sampleRate >= 8000 && ctx.sampleRate <= 96000)) ? ctx.sampleRate : 44100);
+            (win.OfflineAudioContext && (ctx.sampleRate >= 8000 && ctx.sampleRate <= 96000)) ? ctx.sampleRate : 44100);
         this._unlocked = false;
 
         this.compressor = compressor;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -77,7 +77,8 @@ class WebAudioContext extends Filterable implements IMediaContext
         this._ctx = ctx;
         // ios11 safari's webkitOfflineAudioContext allows only 44100 Hz sample rate
         this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2,
-            (win.OfflineAudioContext) ? ctx.sampleRate : 44100);
+            ((win.OfflineAudioContext) && (8000 <= ctx.sampleRate && ctx.sampleRate <= 96000))
+            ? ctx.sampleRate : 44100);
         this._unlocked = false;
 
         this.compressor = compressor;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -77,7 +77,7 @@ class WebAudioContext extends Filterable implements IMediaContext
         this._ctx = ctx;
         // ios11 safari's webkitOfflineAudioContext allows only 44100 Hz sample rate
         this._offlineCtx = new WebAudioContext.OfflineAudioContext(1, 2,
-            (win.OfflineAudioContext && (ctx.sampleRate >= 8000 && ctx.sampleRate <= 96000)) ? ctx.sampleRate : 44100);
+            (win.OfflineAudioContext) ? Math.max(8000, Math.min(96000, ctx.sampleRate)) : 44100);
         this._unlocked = false;
 
         this.compressor = compressor;


### PR DESCRIPTION
I got a report from a user of my web app, which depends on pixi sound, that in their Firefox browser it does not work. On the user's browser console, there was a log like the following:
`Uncaught DOMException: OfflineAudioContext constructor: Sample rate 384000 is not in the range [8000, 192000]`

I found that this happens because on the user's Firefox browser, `new AudioContext().sampleRate` eqauls `384000`,
and the pixi sound source passes this value to the `OfflineAudioContext` constructor without checking whether the value is in a valid rage.

I found that [8000, 96000] can be a valid range:
https://www.w3.org/TR/webaudio/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate
https://www.w3.org/TR/webaudio/#dom-baseaudiocontext-createbuffer

This PR includes a commit that checks whether the value passed to sampleRate parameter of
OfflineAudioContext is in the rage [8000, 96000]. If the value is in the rage, it passes the value. Otherwise, it passes `44100`.

