### PR TITLE
Fixing error when safari rejects with null

### DIFF
--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -290,7 +290,7 @@ class WebAudioContext extends Filterable implements IMediaContext
     {
         const handleError = (err: Error) =>
         {
-            callback(new Error(err.message || 'Unable to decode file'));
+            callback(new Error(err?.message || 'Unable to decode file'));
         };
         const result = this._offlineCtx.decodeAudioData(
             arrayBuffer, (buffer: AudioBuffer) =>


### PR DESCRIPTION
Safari likes to reject the promise with null, giving us an error when we try to read the `message` field of null

https://stackoverflow.com/a/66453990