### PR TITLE
Support extensions API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "mkdirp": "^0.5.1",
         "npm-run-all": "^4.1.5",
         "nyc": "^14.1.0",
-        "pixi.js": "^6.2.1",
+        "pixi.js": "^6.5.3",
         "pre-commit": "^1.2.2",
         "rimraf": "^2.6.3",
         "rollup": "^2.0.0",
@@ -45,10 +45,10 @@
         "yarn": "please-use-npm"
       },
       "peerDependencies": {
-        "@pixi/core": ">=5",
-        "@pixi/loaders": ">=5",
-        "@pixi/ticker": ">=5",
-        "@pixi/utils": ">=5"
+        "@pixi/core": ">=5 <7",
+        "@pixi/loaders": ">=5 <7",
+        "@pixi/ticker": ">=5 <7",
+        "@pixi/utils": ">=5 <7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -768,69 +768,74 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.2.1.tgz",
-      "integrity": "sha512-zXgXx3BostasR69a68BDGVMEjL5CWBct+LtongU1T8HgdXbu2BPaZ/Z679pMj23+5oAR0mUeoH7qTTyRQ2kS3g==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.3.tgz",
+      "integrity": "sha512-Rv7JiK+5anHrHV3Z4uG6KHlPvXNqAN7rZbyTJXjhRyhhJU9qymazko+tLNwYFVpogwU6iTf+PBSaECDL1S4ZWg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.2.1.tgz",
-      "integrity": "sha512-J1dlu4PTF6O9WfHKTs0pg3NSePW2+8M2yMrivR7R/Z3CmmebnRiquua7U/avQXkLVJBwGdSyij2e6fN8dvnUXw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.3.tgz",
+      "integrity": "sha512-n7GVUFcRGj4AIGJ296xzx9PtwnL76D03zQNyVmuv6Ub7IER8nEvtLkxvKakikhJBAXgM15PbSVxfFV/D3Byang==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3"
       }
     },
     "node_modules/@pixi/compressed-textures": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.2.1.tgz",
-      "integrity": "sha512-ZtmitA5ClIBqBo/dR1pd2n/y/xxOC+UKAj1S04FZiXaekYjmcsPUKxbq2Mgp8Qk2PBdz98HSQ4/xOGAYBMWrdQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.3.tgz",
+      "integrity": "sha512-WYdwWw2OWpr+ZUaKT3DPrByrJb0cWi2tPeGu5ACtmL0J99GtE3XqqYOnhj2QG+TifcmQ2LsrCPs+tg9yq5pEqw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/loaders": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/loaders": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.2.1.tgz",
-      "integrity": "sha512-Dppt6rjYP4mIvJCY1I38XhPSfXoOm+A+ERKljLjcvcxVAMhqCTVz3YMp2cUzaio6DtQutiQ6tT06M40xlBZ/lA=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.3.tgz",
+      "integrity": "sha512-h/0Sf6ak0f0bLKo87CQDAUi9+VbAerJi8uKsq4d1DyXYGCNizjIiBVBUfWAPmzJ7JQ79hMn3fYXWCzlp4flKfw=="
     },
     "node_modules/@pixi/core": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.2.1.tgz",
-      "integrity": "sha512-Ndh4/sNXWEkDeU5waWBCsMMPPaQv5uXLyepPXJE0emHBtgJOjKEHa79hrr0p1I2KN7Q8+mw8WlK55yVGuHroIA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.3.tgz",
+      "integrity": "sha512-537nYn5RmXrjSiaDUa5O6Rg72JifoAuKDw2YtAlg9LvoY8jKo2ZP3NvIqrMo2GIjD/I2mznGcU+s9VPzP8lBCQ==",
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/runner": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/ticker": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/extensions": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/runner": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/ticker": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.2.1.tgz",
-      "integrity": "sha512-4taHTgQeAWXrxB4WV0CsyarFEVuI8seKU+12S57c8nQGRYESfDUx4jFatWfgMHY2xCNwCdPTCvlSJzT5ou8VWA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.3.tgz",
+      "integrity": "sha512-Oq51rmnaqbv08z+CuSi75GPKyrzrDi96A1J7mNMJMq4CV6zrwSzCrjo6fcK1Fa47fHRbnkvOqhMQ5aR6NV09MA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/math": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/math": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/eslint-config": {
@@ -847,192 +852,198 @@
         "typescript": ">=3.8.3"
       }
     },
+    "node_modules/@pixi/extensions": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.3.tgz",
+      "integrity": "sha512-5I9wKGMGIy/Nnm+SX4k70i4LkSo/jFNPyMixNYzJyX+gEoLiQawyJ0qD9WJHDCPtwMaBV8d2OzXxZT5wdbIx2w=="
+    },
     "node_modules/@pixi/extract": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.2.1.tgz",
-      "integrity": "sha512-11MTxqXaZlsYRf9QumEDqZXoTb2RlIwpL42k7CnY7ycP+pu8TV+HB5NfLzFltCjnzXuBbl0/bz8eYeU5cSlVkA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.3.tgz",
+      "integrity": "sha512-iE0czpUr3slfqNAKrhA3Cy340HtyMCThcMRL/jvaITiHFUsoWQkt1qCZKkfehKXzAu/KVphPDj0Vg+uCvpXI/Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.2.1.tgz",
-      "integrity": "sha512-f/xSY+T9JnpzrtB2F1EOsGr6urgln6Wdr/NQgVk13L/g8jrM/PhMlbDsodEwf5IL/2xRjAFwYjCFMgzWVXALkw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.3.tgz",
+      "integrity": "sha512-1mFOv/vK5cBvCIcGXEBUVtXkvgEfbUJFSxhF2AOuVN12Kdbv6lgK1r86ylfcUxoymjKWycSwnNZI/5qguk1OMQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1"
+        "@pixi/core": "6.5.3"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.2.1.tgz",
-      "integrity": "sha512-5pIcdL4u5WAwGHsI8uNovb4iK50l+7Dz1ZIwuwbkGU8Xoti/dzeox4bgywnXPq+yN33/Ty0nwd7VYuHmaNl/Rw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.3.tgz",
+      "integrity": "sha512-AmcUFfiWweGdWvDJTSZGZAERjdwNf2DwnAgCgOUqsODlkGwUUIEWiQnIuzlIIT6ztksydB5sxQ65O3aFb/Jpkg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/settings": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/settings": "6.5.3"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.2.1.tgz",
-      "integrity": "sha512-f3yyaruhr8lAVv13YpMb5L4yolvuTygq05CvM3OIFK+dP5bYar2cajGc1Zu0bR3VGF03N8JeHxCUwfMwV7V7AA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.3.tgz",
+      "integrity": "sha512-zXOrAkmtlJbf2ZRPF6su/Y9CY0JvSuqReohrs7Wzfr68AanMUID2yvgzuT/m2iObBh3pNzVuFf+QbhPzOTJG9g==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1"
+        "@pixi/core": "6.5.3"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.2.1.tgz",
-      "integrity": "sha512-o/MjC3tz1y3qZwf22FThGSqfn+zN5bMaBoXn+xSfCqC48thg9vgl2REq0jerDDMVSMW8vUvBUARfT+Wfm3SMDw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.3.tgz",
+      "integrity": "sha512-htfRrkgnm2rQ5IA8e+yzNcQFNLdZZthr09KZZnfmsZ+ulMPl/ZDeWC0uPUdmXDaxGkbahPDuINC/ax9uhoPcRw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/math": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/math": "6.5.3"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.2.1.tgz",
-      "integrity": "sha512-mIiAhBBDrOOPm1UF4isp7ti3d0y1y0xIZJnYbi15/Stmi1EQsMckDKg+V5uq9qbSm1jP3KoYq9dd7Oz/lr9srw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.3.tgz",
+      "integrity": "sha512-+H0ySSucQf0IGi3YpoWWVEDOwu+aw5yrU4kW0cmoNqWVmP0SsmxaWT7H6REJyjcgfgsdkD6JPtEHQSVWfLs5yQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1"
+        "@pixi/core": "6.5.3"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.2.1.tgz",
-      "integrity": "sha512-jDIKo65p1VbqfUKuvb9UaNWaL4SRoc0SMYUwhSJcPjaWKv5bl7Ifqa6b/iQ31ZGHZGSot2ypwFeBiZLG1ndInQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.3.tgz",
+      "integrity": "sha512-yj3RElbNXOB0cRo7K4R38+n/2VZIGQwFdPx3K1iXTWZEzRDT1UXulzbMn2yeCjvDlXqhOhURgQJ3uk1atUs/gw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1"
+        "@pixi/core": "6.5.3"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.2.1.tgz",
-      "integrity": "sha512-/MQREXYx+/glVAQLyNTLnd9+C1Bktm/F1XDzu5swDQSRH2Fo1rCh3mPw0dmJmrWrOOpBTO2+W7Kgm6NkENw9qA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.3.tgz",
+      "integrity": "sha512-jALPefMEadpW4A/ryf3ALo+a8RY3vPcSUAuSu+W60zBhWcLas5O7doNmdwkBNSp06sYalvdl64xs1oBwaoxWQg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/sprite": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.2.1.tgz",
-      "integrity": "sha512-WsubcDQt447+JtDhDHNfkmkEah4Ytry5WYIKbUZSvBdIc9LVXHPLQ+gM4mKkprEV8ZsQb6H/NbmtIKxjxHGYvw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.3.tgz",
+      "integrity": "sha512-edaqZ9VbOUZI5njm5E+jWKQ8bARqda0kVX4UQfjiNqlQKS5a6W6BPW0iR8GkG3iosNpjiUbfDspLD5JGukXb+w==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/ticker": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/ticker": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.2.1.tgz",
-      "integrity": "sha512-UB1uYb3HL4uN1q+w916DNLIZzz7gkg3p4QQRmBXq08Dnj8DWCghPRAfTGfCu3ORqYqEwSaZ+ulLT+SRfHryvyQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.3.tgz",
+      "integrity": "sha512-vh2AEI31KJBUwqRjfJn4il0gkAqKziqwHSg1tlSy3/8BXyLZe9+fy3saL8F5+AWZEWxNQb22E8bLGLwZ6A2Sdg==",
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.2.1.tgz",
-      "integrity": "sha512-ejAHHbJSRtAhpFVFOQ4niavCDkjISWBxjFQoqznManDZKXBH0vf8EQBWSth5Cp9wXXAG0mAt4gzlwYXEf7Axkg=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.3.tgz",
+      "integrity": "sha512-0BK/9PB/9vqAln8VBAYJHVOZdugU3JW139rwUWqgzpgcPTRVbKlaQR85Jg3RkvB0rYukxurdX4/mLQTfOmdRVg=="
     },
     "node_modules/@pixi/mesh": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.2.1.tgz",
-      "integrity": "sha512-ekLhRxk6g8sVwrEj3xtVNmyCoCgKSIlqVYL26a2QWYAllWeP1FZiCmBJGk6FAXlIrzG76+aymiUVH35pD1gZvw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.3.tgz",
+      "integrity": "sha512-8RsUaGEn5nlyMvhasx0+88i/oHGWIeNS3HliiXuKJEMiKs90sbt0KTvR/L2KIW27xisvRyEQ5Hr7VE4NjGSeSQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.2.1.tgz",
-      "integrity": "sha512-mgIRiW4W5aOI1lDawNBTNsDZAy+qBGwwBgYsvRqjqOK6cxQ2pnDSEvphK3k2k+Qk2zUBFzqIxSWcG9EWnDQf2Q==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.3.tgz",
+      "integrity": "sha512-gnY/b8gfmU75DundYWxL3Hbw9wApyG3xT0+IgPaJk5bz9ekMPohjlHnJAkFGszSYjK7nZ6LM5niIE/KcIhtFDQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/mesh": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/mesh": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.2.1.tgz",
-      "integrity": "sha512-+KsDxCrlvWK2S4ExaKMWFp5RPiFxbBZS2rQ3yrA5GTUC4uZUWm3QptVjHmWb1kjgD5l/QOGF40ZFTu8FfqXtlg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.3.tgz",
+      "integrity": "sha512-kUUqBWaV9wfoFEpf5UJPDEuTEc1dujfuI1AoNNWzkFu5Pv0jwTvE5VfwGFPFRmGWH5SX0PhdyoaZIQY7TrZ77A==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/sprite": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.2.1.tgz",
-      "integrity": "sha512-Osrydgec/Zqu1rxz3wJlNH8qe3a8qyOC6dvzS0QlU6gIe7EUfqFSKSCsnht8zDFTNOBPL/hzG1JKDWTOBqRj8g==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.3.tgz",
+      "integrity": "sha512-KxiX81Xf/Gz1XorsfRmM+xGFzSjFS2CgaasNls3lWt/eH2pIiiOCmLZWe+Y0UL/kYqXoA8Kr2liTe9DoO7rkAA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.2.1"
+        "@pixi/display": "6.5.3"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.2.1.tgz",
-      "integrity": "sha512-3W5u3b5A4U6glUMPal1/8vug5gs5CIlum9K30VnNQ2Q2bC4mZ6CEBHVIN6pG7ekg3E7xbLwp/WlZM9wZ1yr7ng==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.3.tgz",
+      "integrity": "sha512-mqT+Or7gs+40d9u6GW9D/g6zJK/AiVulExHFtIv+JU5c6sTK8aiBI8DCtjGiKY5z/NQz4ah4e8Wd6kx5Wd25Pw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1"
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3"
       }
     },
     "node_modules/@pixi/particle-container": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.2.1.tgz",
-      "integrity": "sha512-uk8erald8eGiucE0336YTIOS4e1HkSYc8ZYkJnCfxEPcOSMyPEmInI+kWtq0IHa1icX9G4zZRh9rj3vCfCLY+A==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.3.tgz",
+      "integrity": "sha512-DGM53rxHEXQXEBuXg47xW+YdljwdFiKXp0Y4D4Siebu316qpM4vwMImNL7wcFCju7rNcSNJnfKCO3h9/hT3uZQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.2.1.tgz",
-      "integrity": "sha512-t7xHLTq3L1FBWT65LR+L1rTjqFq6yDAS+07cG4GCp1TrjcBGV4RGNuB4VhlQOsxVJIhzzEry+3TQt6/EenQ5TQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.3.tgz",
+      "integrity": "sha512-94XxcZFpDwiTm88pumm/K5YxHQKkmJRY9oAtrsOc5nbYs9cCT71xih+9Ctu/t93BZP+sfXiAxMpx+Fl8L8MYQQ==",
       "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -1040,134 +1051,133 @@
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.2.1.tgz",
-      "integrity": "sha512-SsNnZilq0gikrO/LjL+gEaUzmrFpkNeROgyfT6Pa3l2HWqG4eoU+iPxSH3f0WshYyZPLF793ryFut9tSJKLCSw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.3.tgz",
+      "integrity": "sha512-mBhL6GrgYWfw/G3ZFH6vDHf6T7y9q5LvWFprJeP0I9DmNLMz3EQAmgjO8tsPsTp2SANcrDhazhfy/yqQ8Eeqgg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/graphics": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/text": "6.2.1",
-        "@pixi/ticker": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/graphics": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/text": "6.5.3",
+        "@pixi/ticker": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.2.1.tgz",
-      "integrity": "sha512-m3dB5b212WJ3wa7QGBY27NckHtQu1TR2FwtEeMyL0g0tSfCf1ve0Pegf39q9PQ4D1/C1j0n58JuKBqSf9oH66Q=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.3.tgz",
+      "integrity": "sha512-yUFKlu6m4525lRY9VqVOftQOeJAzCfpHH4k3O1LszmJyQy71QoKQhcnsMLvld7+sf0smw7s4uFpF5xeF0UPTwA=="
     },
     "node_modules/@pixi/settings": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.2.1.tgz",
-      "integrity": "sha512-GVgLgTdEMZDSEyly+yX+49MhVzEiSyJCHItAurLUVGLvi443AcRuK57mYVNDdTfOn2VRIvwW7FNgwdrzq58WWQ==",
-      "dependencies": {
-        "ismobilejs": "^1.1.0"
-      }
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.3.tgz",
+      "integrity": "sha512-3T2WCjO37kLuAFDLkfumtWjQMETChANRB2u5cYpCqwss8cO/QiGLW25/tNx12GuI6p6QiGx/SjsT4OoNHiPSgg=="
     },
     "node_modules/@pixi/sprite": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.2.1.tgz",
-      "integrity": "sha512-NV4mS3vUcVgi9qKtY3SH/tf5goinCAJId3bmj76MAlBDNaE8wyu7bEcWLQFIHC59zxJCOd5D/iOmDqVKiOu4Dw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.3.tgz",
+      "integrity": "sha512-ly/OBTwpuoPpk9w9xSOsJ0/dM4pu2MdghVzqDYjsODqSq9eibCsFwpOnPLhtTV8letoODc0V9XJKqog2vr03Ag==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.2.1.tgz",
-      "integrity": "sha512-puJtJFcHgyYuWf4EdFOVMFimtQsTxskNwI/CMw5HQBuz8dPB3aHensVGyv7mPzr0zpl7Ruzb6l+F5Y/G6jbugg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.3.tgz",
+      "integrity": "sha512-PzPZ6c9hngwgcWmt1DwA810Kr/afgHwsXzm8Sn/JSJlUo3Itmeur/zlHZ72Qt1QfnN34+uPQoOiv89xtDN93Fw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/sprite": "6.2.1",
-        "@pixi/ticker": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/ticker": "6.5.3"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.2.1.tgz",
-      "integrity": "sha512-YPPqRRBp7JvQq1MjGU7IaKL+7WNeSsHNjUlQfawPR3XvNFLKb7zks1DvR09AziMm8u4h6/wfejFuRycqg/3gvQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.3.tgz",
+      "integrity": "sha512-Shf771SSmOOSBrleo8vWb+GjNMFXNZKUbrRl9an3n6f8zdvb9xfjolFiRHm7OVJGcvxb46Xw/6nfRHJWRZZ5yg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/sprite": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.2.1.tgz",
-      "integrity": "sha512-mCJn3044/VX2Z0nGr+5brWR2F9akKzKAI4OBqmQU4mfiy7Q4+MM0Fgk9vHc7wKCuhUz//U7SmK6CdCqZknVaAA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.3.tgz",
+      "integrity": "sha512-yuTFFnma6eFODdFNdT8TJ2UaIa2CgcVZ3dHG7EI9HHYzx5pDXRk+v0LoHb+q7dO2Tm2yC9jcEJXfmO5Qmx+D8A==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/loaders": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/loaders": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.2.1.tgz",
-      "integrity": "sha512-vTwXm6RVcSa4RXlqknxf1y7Q35fyOWIlERz3eb6STcoGFOwbXSjdIsAkamjKzbasfF0rSe910QHYxs2XWJ6ozA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.3.tgz",
+      "integrity": "sha512-SNK+tPm3xb2FT57sSf4Jn+FjZzLzDrv9PPkFBRiYV/eqMPs0jpdSRPN5KxkDDT/SbDsmi6HZGM0p+/G/7ydAzA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/sprite": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/core": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.2.1.tgz",
-      "integrity": "sha512-fbOz1aTyXUu0+fuWVnL6eGu5WhpQlF83GM8CKBo2j4NqhxYnkIn4r5g2QSYXVAZ5PSeUjGO0o7lUKxZN0Wq2gg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.3.tgz",
+      "integrity": "sha512-QJ2o2/WifrQ0enJ7Kx10w6V3TYNb/Z/HOkWsR4PBEFKOZM5Os+vyaF/VeEDrcvpCDL840wRbYFQVxd7ILfbiGw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/loaders": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/mesh": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/text": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/loaders": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/mesh": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/text": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.2.1.tgz",
-      "integrity": "sha512-J9UCTIJswM7HO76CtBpJAB+EMBxElmJ+JV9uTUQBGZVc6cmQI9JPPx1QcDWVkuF4qv1Keeh0Tjhnq8Sjc701AA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.3.tgz",
+      "integrity": "sha512-4RHoPxCdH8017HaY+l/F6xTS8igNja5sEQtyXSWlPvd1Y3jnifmIvzi8nrpn7JIHpeN7iHenRCjyM3UYEyUr7g==",
       "peerDependencies": {
-        "@pixi/settings": "6.2.1"
+        "@pixi/extensions": "6.5.3",
+        "@pixi/settings": "6.5.3"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.2.1.tgz",
-      "integrity": "sha512-aLOIzDZ6ccJ/DfGs9vldjWXn3RHpOMR26Bkr3aeynn/p1rdY3n2dzC8oKWwVb3gPQWmsEZJa8QuLvOiIwHqAJg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.3.tgz",
+      "integrity": "sha512-zucVQSByYoJeKAfVaYMDvF9ku8y79aUhnHDWEUt1lNNi5hbnMzIGxKkB2R/IPct5ASulQmJBvW9t/MS/UKVc2Q==",
       "dependencies": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
+        "earcut": "^2.2.4",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.2.1",
-        "@pixi/settings": "6.2.1"
+        "@pixi/constants": "6.5.3",
+        "@pixi/settings": "6.5.3"
       }
     },
     "node_modules/@pixi/webdoc-template": {
@@ -1376,8 +1386,7 @@
     "node_modules/@types/offscreencanvas": {
       "version": "2019.6.4",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
-      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q==",
-      "dev": true
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.9.0",
@@ -3150,9 +3159,9 @@
       "dev": true
     },
     "node_modules/earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/ecstatic": {
       "version": "3.3.2",
@@ -5437,11 +5446,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
-    },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -7338,46 +7342,47 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.2.1.tgz",
-      "integrity": "sha512-oZaa4QAkzcYnXRBH3O8u2LuUVO6gTPKSZijZIYhv6+EDBULZvPxlOZf7jFQNpXVgKAXhptQmOytO1LnWMuK2Sg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.3.tgz",
+      "integrity": "sha512-WaZcbJIhc4J0oHOWCG+8XRfbBYzH8FPmV/w+OcPEX4L2pv8leBY2WOSrcyPjItpYC+NnZad/VHMq1J+zZnB4Pg==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "6.2.1",
-        "@pixi/app": "6.2.1",
-        "@pixi/compressed-textures": "6.2.1",
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/extract": "6.2.1",
-        "@pixi/filter-alpha": "6.2.1",
-        "@pixi/filter-blur": "6.2.1",
-        "@pixi/filter-color-matrix": "6.2.1",
-        "@pixi/filter-displacement": "6.2.1",
-        "@pixi/filter-fxaa": "6.2.1",
-        "@pixi/filter-noise": "6.2.1",
-        "@pixi/graphics": "6.2.1",
-        "@pixi/interaction": "6.2.1",
-        "@pixi/loaders": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/mesh": "6.2.1",
-        "@pixi/mesh-extras": "6.2.1",
-        "@pixi/mixin-cache-as-bitmap": "6.2.1",
-        "@pixi/mixin-get-child-by-name": "6.2.1",
-        "@pixi/mixin-get-global-position": "6.2.1",
-        "@pixi/particle-container": "6.2.1",
-        "@pixi/polyfill": "6.2.1",
-        "@pixi/prepare": "6.2.1",
-        "@pixi/runner": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/sprite": "6.2.1",
-        "@pixi/sprite-animated": "6.2.1",
-        "@pixi/sprite-tiling": "6.2.1",
-        "@pixi/spritesheet": "6.2.1",
-        "@pixi/text": "6.2.1",
-        "@pixi/text-bitmap": "6.2.1",
-        "@pixi/ticker": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/accessibility": "6.5.3",
+        "@pixi/app": "6.5.3",
+        "@pixi/compressed-textures": "6.5.3",
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/extensions": "6.5.3",
+        "@pixi/extract": "6.5.3",
+        "@pixi/filter-alpha": "6.5.3",
+        "@pixi/filter-blur": "6.5.3",
+        "@pixi/filter-color-matrix": "6.5.3",
+        "@pixi/filter-displacement": "6.5.3",
+        "@pixi/filter-fxaa": "6.5.3",
+        "@pixi/filter-noise": "6.5.3",
+        "@pixi/graphics": "6.5.3",
+        "@pixi/interaction": "6.5.3",
+        "@pixi/loaders": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/mesh": "6.5.3",
+        "@pixi/mesh-extras": "6.5.3",
+        "@pixi/mixin-cache-as-bitmap": "6.5.3",
+        "@pixi/mixin-get-child-by-name": "6.5.3",
+        "@pixi/mixin-get-global-position": "6.5.3",
+        "@pixi/particle-container": "6.5.3",
+        "@pixi/polyfill": "6.5.3",
+        "@pixi/prepare": "6.5.3",
+        "@pixi/runner": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/sprite-animated": "6.5.3",
+        "@pixi/sprite-tiling": "6.5.3",
+        "@pixi/spritesheet": "6.5.3",
+        "@pixi/text": "6.5.3",
+        "@pixi/text-bitmap": "6.5.3",
+        "@pixi/ticker": "6.5.3",
+        "@pixi/utils": "6.5.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7647,9 +7652,9 @@
       }
     },
     "node_modules/promise-polyfill": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
-      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
       "dev": true
     },
     "node_modules/proto-list": {
@@ -10503,41 +10508,43 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.2.1.tgz",
-      "integrity": "sha512-zXgXx3BostasR69a68BDGVMEjL5CWBct+LtongU1T8HgdXbu2BPaZ/Z679pMj23+5oAR0mUeoH7qTTyRQ2kS3g==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.3.tgz",
+      "integrity": "sha512-Rv7JiK+5anHrHV3Z4uG6KHlPvXNqAN7rZbyTJXjhRyhhJU9qymazko+tLNwYFVpogwU6iTf+PBSaECDL1S4ZWg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/app": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.2.1.tgz",
-      "integrity": "sha512-J1dlu4PTF6O9WfHKTs0pg3NSePW2+8M2yMrivR7R/Z3CmmebnRiquua7U/avQXkLVJBwGdSyij2e6fN8dvnUXw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.3.tgz",
+      "integrity": "sha512-n7GVUFcRGj4AIGJ296xzx9PtwnL76D03zQNyVmuv6Ub7IER8nEvtLkxvKakikhJBAXgM15PbSVxfFV/D3Byang==",
       "dev": true,
       "requires": {}
     },
     "@pixi/compressed-textures": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.2.1.tgz",
-      "integrity": "sha512-ZtmitA5ClIBqBo/dR1pd2n/y/xxOC+UKAj1S04FZiXaekYjmcsPUKxbq2Mgp8Qk2PBdz98HSQ4/xOGAYBMWrdQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.3.tgz",
+      "integrity": "sha512-WYdwWw2OWpr+ZUaKT3DPrByrJb0cWi2tPeGu5ACtmL0J99GtE3XqqYOnhj2QG+TifcmQ2LsrCPs+tg9yq5pEqw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/constants": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.2.1.tgz",
-      "integrity": "sha512-Dppt6rjYP4mIvJCY1I38XhPSfXoOm+A+ERKljLjcvcxVAMhqCTVz3YMp2cUzaio6DtQutiQ6tT06M40xlBZ/lA=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.3.tgz",
+      "integrity": "sha512-h/0Sf6ak0f0bLKo87CQDAUi9+VbAerJi8uKsq4d1DyXYGCNizjIiBVBUfWAPmzJ7JQ79hMn3fYXWCzlp4flKfw=="
     },
     "@pixi/core": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.2.1.tgz",
-      "integrity": "sha512-Ndh4/sNXWEkDeU5waWBCsMMPPaQv5uXLyepPXJE0emHBtgJOjKEHa79hrr0p1I2KN7Q8+mw8WlK55yVGuHroIA==",
-      "requires": {}
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.3.tgz",
+      "integrity": "sha512-537nYn5RmXrjSiaDUa5O6Rg72JifoAuKDw2YtAlg9LvoY8jKo2ZP3NvIqrMo2GIjD/I2mznGcU+s9VPzP8lBCQ==",
+      "requires": {
+        "@types/offscreencanvas": "^2019.6.4"
+      }
     },
     "@pixi/display": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.2.1.tgz",
-      "integrity": "sha512-4taHTgQeAWXrxB4WV0CsyarFEVuI8seKU+12S57c8nQGRYESfDUx4jFatWfgMHY2xCNwCdPTCvlSJzT5ou8VWA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.3.tgz",
+      "integrity": "sha512-Oq51rmnaqbv08z+CuSi75GPKyrzrDi96A1J7mNMJMq4CV6zrwSzCrjo6fcK1Fa47fHRbnkvOqhMQ5aR6NV09MA==",
       "dev": true,
       "requires": {}
     },
@@ -10551,126 +10558,131 @@
         "@typescript-eslint/parser": "^5.0.0"
       }
     },
+    "@pixi/extensions": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.3.tgz",
+      "integrity": "sha512-5I9wKGMGIy/Nnm+SX4k70i4LkSo/jFNPyMixNYzJyX+gEoLiQawyJ0qD9WJHDCPtwMaBV8d2OzXxZT5wdbIx2w=="
+    },
     "@pixi/extract": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.2.1.tgz",
-      "integrity": "sha512-11MTxqXaZlsYRf9QumEDqZXoTb2RlIwpL42k7CnY7ycP+pu8TV+HB5NfLzFltCjnzXuBbl0/bz8eYeU5cSlVkA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.3.tgz",
+      "integrity": "sha512-iE0czpUr3slfqNAKrhA3Cy340HtyMCThcMRL/jvaITiHFUsoWQkt1qCZKkfehKXzAu/KVphPDj0Vg+uCvpXI/Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-alpha": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.2.1.tgz",
-      "integrity": "sha512-f/xSY+T9JnpzrtB2F1EOsGr6urgln6Wdr/NQgVk13L/g8jrM/PhMlbDsodEwf5IL/2xRjAFwYjCFMgzWVXALkw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.3.tgz",
+      "integrity": "sha512-1mFOv/vK5cBvCIcGXEBUVtXkvgEfbUJFSxhF2AOuVN12Kdbv6lgK1r86ylfcUxoymjKWycSwnNZI/5qguk1OMQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-blur": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.2.1.tgz",
-      "integrity": "sha512-5pIcdL4u5WAwGHsI8uNovb4iK50l+7Dz1ZIwuwbkGU8Xoti/dzeox4bgywnXPq+yN33/Ty0nwd7VYuHmaNl/Rw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.3.tgz",
+      "integrity": "sha512-AmcUFfiWweGdWvDJTSZGZAERjdwNf2DwnAgCgOUqsODlkGwUUIEWiQnIuzlIIT6ztksydB5sxQ65O3aFb/Jpkg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-color-matrix": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.2.1.tgz",
-      "integrity": "sha512-f3yyaruhr8lAVv13YpMb5L4yolvuTygq05CvM3OIFK+dP5bYar2cajGc1Zu0bR3VGF03N8JeHxCUwfMwV7V7AA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.3.tgz",
+      "integrity": "sha512-zXOrAkmtlJbf2ZRPF6su/Y9CY0JvSuqReohrs7Wzfr68AanMUID2yvgzuT/m2iObBh3pNzVuFf+QbhPzOTJG9g==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-displacement": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.2.1.tgz",
-      "integrity": "sha512-o/MjC3tz1y3qZwf22FThGSqfn+zN5bMaBoXn+xSfCqC48thg9vgl2REq0jerDDMVSMW8vUvBUARfT+Wfm3SMDw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.3.tgz",
+      "integrity": "sha512-htfRrkgnm2rQ5IA8e+yzNcQFNLdZZthr09KZZnfmsZ+ulMPl/ZDeWC0uPUdmXDaxGkbahPDuINC/ax9uhoPcRw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-fxaa": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.2.1.tgz",
-      "integrity": "sha512-mIiAhBBDrOOPm1UF4isp7ti3d0y1y0xIZJnYbi15/Stmi1EQsMckDKg+V5uq9qbSm1jP3KoYq9dd7Oz/lr9srw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.3.tgz",
+      "integrity": "sha512-+H0ySSucQf0IGi3YpoWWVEDOwu+aw5yrU4kW0cmoNqWVmP0SsmxaWT7H6REJyjcgfgsdkD6JPtEHQSVWfLs5yQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-noise": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.2.1.tgz",
-      "integrity": "sha512-jDIKo65p1VbqfUKuvb9UaNWaL4SRoc0SMYUwhSJcPjaWKv5bl7Ifqa6b/iQ31ZGHZGSot2ypwFeBiZLG1ndInQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.3.tgz",
+      "integrity": "sha512-yj3RElbNXOB0cRo7K4R38+n/2VZIGQwFdPx3K1iXTWZEzRDT1UXulzbMn2yeCjvDlXqhOhURgQJ3uk1atUs/gw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/graphics": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.2.1.tgz",
-      "integrity": "sha512-/MQREXYx+/glVAQLyNTLnd9+C1Bktm/F1XDzu5swDQSRH2Fo1rCh3mPw0dmJmrWrOOpBTO2+W7Kgm6NkENw9qA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.3.tgz",
+      "integrity": "sha512-jALPefMEadpW4A/ryf3ALo+a8RY3vPcSUAuSu+W60zBhWcLas5O7doNmdwkBNSp06sYalvdl64xs1oBwaoxWQg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/interaction": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.2.1.tgz",
-      "integrity": "sha512-WsubcDQt447+JtDhDHNfkmkEah4Ytry5WYIKbUZSvBdIc9LVXHPLQ+gM4mKkprEV8ZsQb6H/NbmtIKxjxHGYvw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.3.tgz",
+      "integrity": "sha512-edaqZ9VbOUZI5njm5E+jWKQ8bARqda0kVX4UQfjiNqlQKS5a6W6BPW0iR8GkG3iosNpjiUbfDspLD5JGukXb+w==",
       "dev": true,
       "requires": {}
     },
     "@pixi/loaders": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.2.1.tgz",
-      "integrity": "sha512-UB1uYb3HL4uN1q+w916DNLIZzz7gkg3p4QQRmBXq08Dnj8DWCghPRAfTGfCu3ORqYqEwSaZ+ulLT+SRfHryvyQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.3.tgz",
+      "integrity": "sha512-vh2AEI31KJBUwqRjfJn4il0gkAqKziqwHSg1tlSy3/8BXyLZe9+fy3saL8F5+AWZEWxNQb22E8bLGLwZ6A2Sdg==",
       "requires": {}
     },
     "@pixi/math": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.2.1.tgz",
-      "integrity": "sha512-ejAHHbJSRtAhpFVFOQ4niavCDkjISWBxjFQoqznManDZKXBH0vf8EQBWSth5Cp9wXXAG0mAt4gzlwYXEf7Axkg=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.3.tgz",
+      "integrity": "sha512-0BK/9PB/9vqAln8VBAYJHVOZdugU3JW139rwUWqgzpgcPTRVbKlaQR85Jg3RkvB0rYukxurdX4/mLQTfOmdRVg=="
     },
     "@pixi/mesh": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.2.1.tgz",
-      "integrity": "sha512-ekLhRxk6g8sVwrEj3xtVNmyCoCgKSIlqVYL26a2QWYAllWeP1FZiCmBJGk6FAXlIrzG76+aymiUVH35pD1gZvw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.3.tgz",
+      "integrity": "sha512-8RsUaGEn5nlyMvhasx0+88i/oHGWIeNS3HliiXuKJEMiKs90sbt0KTvR/L2KIW27xisvRyEQ5Hr7VE4NjGSeSQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mesh-extras": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.2.1.tgz",
-      "integrity": "sha512-mgIRiW4W5aOI1lDawNBTNsDZAy+qBGwwBgYsvRqjqOK6cxQ2pnDSEvphK3k2k+Qk2zUBFzqIxSWcG9EWnDQf2Q==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.3.tgz",
+      "integrity": "sha512-gnY/b8gfmU75DundYWxL3Hbw9wApyG3xT0+IgPaJk5bz9ekMPohjlHnJAkFGszSYjK7nZ6LM5niIE/KcIhtFDQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.2.1.tgz",
-      "integrity": "sha512-+KsDxCrlvWK2S4ExaKMWFp5RPiFxbBZS2rQ3yrA5GTUC4uZUWm3QptVjHmWb1kjgD5l/QOGF40ZFTu8FfqXtlg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.3.tgz",
+      "integrity": "sha512-kUUqBWaV9wfoFEpf5UJPDEuTEc1dujfuI1AoNNWzkFu5Pv0jwTvE5VfwGFPFRmGWH5SX0PhdyoaZIQY7TrZ77A==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.2.1.tgz",
-      "integrity": "sha512-Osrydgec/Zqu1rxz3wJlNH8qe3a8qyOC6dvzS0QlU6gIe7EUfqFSKSCsnht8zDFTNOBPL/hzG1JKDWTOBqRj8g==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.3.tgz",
+      "integrity": "sha512-KxiX81Xf/Gz1XorsfRmM+xGFzSjFS2CgaasNls3lWt/eH2pIiiOCmLZWe+Y0UL/kYqXoA8Kr2liTe9DoO7rkAA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.2.1.tgz",
-      "integrity": "sha512-3W5u3b5A4U6glUMPal1/8vug5gs5CIlum9K30VnNQ2Q2bC4mZ6CEBHVIN6pG7ekg3E7xbLwp/WlZM9wZ1yr7ng==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.3.tgz",
+      "integrity": "sha512-mqT+Or7gs+40d9u6GW9D/g6zJK/AiVulExHFtIv+JU5c6sTK8aiBI8DCtjGiKY5z/NQz4ah4e8Wd6kx5Wd25Pw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/particle-container": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.2.1.tgz",
-      "integrity": "sha512-uk8erald8eGiucE0336YTIOS4e1HkSYc8ZYkJnCfxEPcOSMyPEmInI+kWtq0IHa1icX9G4zZRh9rj3vCfCLY+A==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.3.tgz",
+      "integrity": "sha512-DGM53rxHEXQXEBuXg47xW+YdljwdFiKXp0Y4D4Siebu316qpM4vwMImNL7wcFCju7rNcSNJnfKCO3h9/hT3uZQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/polyfill": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.2.1.tgz",
-      "integrity": "sha512-t7xHLTq3L1FBWT65LR+L1rTjqFq6yDAS+07cG4GCp1TrjcBGV4RGNuB4VhlQOsxVJIhzzEry+3TQt6/EenQ5TQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.3.tgz",
+      "integrity": "sha512-94XxcZFpDwiTm88pumm/K5YxHQKkmJRY9oAtrsOc5nbYs9cCT71xih+9Ctu/t93BZP+sfXiAxMpx+Fl8L8MYQQ==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -10678,80 +10690,77 @@
       }
     },
     "@pixi/prepare": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.2.1.tgz",
-      "integrity": "sha512-SsNnZilq0gikrO/LjL+gEaUzmrFpkNeROgyfT6Pa3l2HWqG4eoU+iPxSH3f0WshYyZPLF793ryFut9tSJKLCSw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.3.tgz",
+      "integrity": "sha512-mBhL6GrgYWfw/G3ZFH6vDHf6T7y9q5LvWFprJeP0I9DmNLMz3EQAmgjO8tsPsTp2SANcrDhazhfy/yqQ8Eeqgg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/runner": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.2.1.tgz",
-      "integrity": "sha512-m3dB5b212WJ3wa7QGBY27NckHtQu1TR2FwtEeMyL0g0tSfCf1ve0Pegf39q9PQ4D1/C1j0n58JuKBqSf9oH66Q=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.3.tgz",
+      "integrity": "sha512-yUFKlu6m4525lRY9VqVOftQOeJAzCfpHH4k3O1LszmJyQy71QoKQhcnsMLvld7+sf0smw7s4uFpF5xeF0UPTwA=="
     },
     "@pixi/settings": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.2.1.tgz",
-      "integrity": "sha512-GVgLgTdEMZDSEyly+yX+49MhVzEiSyJCHItAurLUVGLvi443AcRuK57mYVNDdTfOn2VRIvwW7FNgwdrzq58WWQ==",
-      "requires": {
-        "ismobilejs": "^1.1.0"
-      }
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.3.tgz",
+      "integrity": "sha512-3T2WCjO37kLuAFDLkfumtWjQMETChANRB2u5cYpCqwss8cO/QiGLW25/tNx12GuI6p6QiGx/SjsT4OoNHiPSgg=="
     },
     "@pixi/sprite": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.2.1.tgz",
-      "integrity": "sha512-NV4mS3vUcVgi9qKtY3SH/tf5goinCAJId3bmj76MAlBDNaE8wyu7bEcWLQFIHC59zxJCOd5D/iOmDqVKiOu4Dw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.3.tgz",
+      "integrity": "sha512-ly/OBTwpuoPpk9w9xSOsJ0/dM4pu2MdghVzqDYjsODqSq9eibCsFwpOnPLhtTV8letoODc0V9XJKqog2vr03Ag==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-animated": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.2.1.tgz",
-      "integrity": "sha512-puJtJFcHgyYuWf4EdFOVMFimtQsTxskNwI/CMw5HQBuz8dPB3aHensVGyv7mPzr0zpl7Ruzb6l+F5Y/G6jbugg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.3.tgz",
+      "integrity": "sha512-PzPZ6c9hngwgcWmt1DwA810Kr/afgHwsXzm8Sn/JSJlUo3Itmeur/zlHZ72Qt1QfnN34+uPQoOiv89xtDN93Fw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-tiling": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.2.1.tgz",
-      "integrity": "sha512-YPPqRRBp7JvQq1MjGU7IaKL+7WNeSsHNjUlQfawPR3XvNFLKb7zks1DvR09AziMm8u4h6/wfejFuRycqg/3gvQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.3.tgz",
+      "integrity": "sha512-Shf771SSmOOSBrleo8vWb+GjNMFXNZKUbrRl9an3n6f8zdvb9xfjolFiRHm7OVJGcvxb46Xw/6nfRHJWRZZ5yg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/spritesheet": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.2.1.tgz",
-      "integrity": "sha512-mCJn3044/VX2Z0nGr+5brWR2F9akKzKAI4OBqmQU4mfiy7Q4+MM0Fgk9vHc7wKCuhUz//U7SmK6CdCqZknVaAA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.3.tgz",
+      "integrity": "sha512-yuTFFnma6eFODdFNdT8TJ2UaIa2CgcVZ3dHG7EI9HHYzx5pDXRk+v0LoHb+q7dO2Tm2yC9jcEJXfmO5Qmx+D8A==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.2.1.tgz",
-      "integrity": "sha512-vTwXm6RVcSa4RXlqknxf1y7Q35fyOWIlERz3eb6STcoGFOwbXSjdIsAkamjKzbasfF0rSe910QHYxs2XWJ6ozA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.3.tgz",
+      "integrity": "sha512-SNK+tPm3xb2FT57sSf4Jn+FjZzLzDrv9PPkFBRiYV/eqMPs0jpdSRPN5KxkDDT/SbDsmi6HZGM0p+/G/7ydAzA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text-bitmap": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.2.1.tgz",
-      "integrity": "sha512-fbOz1aTyXUu0+fuWVnL6eGu5WhpQlF83GM8CKBo2j4NqhxYnkIn4r5g2QSYXVAZ5PSeUjGO0o7lUKxZN0Wq2gg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.3.tgz",
+      "integrity": "sha512-QJ2o2/WifrQ0enJ7Kx10w6V3TYNb/Z/HOkWsR4PBEFKOZM5Os+vyaF/VeEDrcvpCDL840wRbYFQVxd7ILfbiGw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/ticker": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.2.1.tgz",
-      "integrity": "sha512-J9UCTIJswM7HO76CtBpJAB+EMBxElmJ+JV9uTUQBGZVc6cmQI9JPPx1QcDWVkuF4qv1Keeh0Tjhnq8Sjc701AA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.3.tgz",
+      "integrity": "sha512-4RHoPxCdH8017HaY+l/F6xTS8igNja5sEQtyXSWlPvd1Y3jnifmIvzi8nrpn7JIHpeN7iHenRCjyM3UYEyUr7g==",
       "requires": {}
     },
     "@pixi/utils": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.2.1.tgz",
-      "integrity": "sha512-aLOIzDZ6ccJ/DfGs9vldjWXn3RHpOMR26Bkr3aeynn/p1rdY3n2dzC8oKWwVb3gPQWmsEZJa8QuLvOiIwHqAJg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.3.tgz",
+      "integrity": "sha512-zucVQSByYoJeKAfVaYMDvF9ku8y79aUhnHDWEUt1lNNi5hbnMzIGxKkB2R/IPct5ASulQmJBvW9t/MS/UKVc2Q==",
       "requires": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
+        "earcut": "^2.2.4",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -10928,8 +10937,7 @@
     "@types/offscreencanvas": {
       "version": "2019.6.4",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
-      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q==",
-      "dev": true
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.9.0",
@@ -12288,9 +12296,9 @@
       "dev": true
     },
     "earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "ecstatic": {
       "version": "3.3.2",
@@ -14042,11 +14050,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
-    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -15534,46 +15537,47 @@
       }
     },
     "pixi.js": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.2.1.tgz",
-      "integrity": "sha512-oZaa4QAkzcYnXRBH3O8u2LuUVO6gTPKSZijZIYhv6+EDBULZvPxlOZf7jFQNpXVgKAXhptQmOytO1LnWMuK2Sg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.3.tgz",
+      "integrity": "sha512-WaZcbJIhc4J0oHOWCG+8XRfbBYzH8FPmV/w+OcPEX4L2pv8leBY2WOSrcyPjItpYC+NnZad/VHMq1J+zZnB4Pg==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "6.2.1",
-        "@pixi/app": "6.2.1",
-        "@pixi/compressed-textures": "6.2.1",
-        "@pixi/constants": "6.2.1",
-        "@pixi/core": "6.2.1",
-        "@pixi/display": "6.2.1",
-        "@pixi/extract": "6.2.1",
-        "@pixi/filter-alpha": "6.2.1",
-        "@pixi/filter-blur": "6.2.1",
-        "@pixi/filter-color-matrix": "6.2.1",
-        "@pixi/filter-displacement": "6.2.1",
-        "@pixi/filter-fxaa": "6.2.1",
-        "@pixi/filter-noise": "6.2.1",
-        "@pixi/graphics": "6.2.1",
-        "@pixi/interaction": "6.2.1",
-        "@pixi/loaders": "6.2.1",
-        "@pixi/math": "6.2.1",
-        "@pixi/mesh": "6.2.1",
-        "@pixi/mesh-extras": "6.2.1",
-        "@pixi/mixin-cache-as-bitmap": "6.2.1",
-        "@pixi/mixin-get-child-by-name": "6.2.1",
-        "@pixi/mixin-get-global-position": "6.2.1",
-        "@pixi/particle-container": "6.2.1",
-        "@pixi/polyfill": "6.2.1",
-        "@pixi/prepare": "6.2.1",
-        "@pixi/runner": "6.2.1",
-        "@pixi/settings": "6.2.1",
-        "@pixi/sprite": "6.2.1",
-        "@pixi/sprite-animated": "6.2.1",
-        "@pixi/sprite-tiling": "6.2.1",
-        "@pixi/spritesheet": "6.2.1",
-        "@pixi/text": "6.2.1",
-        "@pixi/text-bitmap": "6.2.1",
-        "@pixi/ticker": "6.2.1",
-        "@pixi/utils": "6.2.1"
+        "@pixi/accessibility": "6.5.3",
+        "@pixi/app": "6.5.3",
+        "@pixi/compressed-textures": "6.5.3",
+        "@pixi/constants": "6.5.3",
+        "@pixi/core": "6.5.3",
+        "@pixi/display": "6.5.3",
+        "@pixi/extensions": "6.5.3",
+        "@pixi/extract": "6.5.3",
+        "@pixi/filter-alpha": "6.5.3",
+        "@pixi/filter-blur": "6.5.3",
+        "@pixi/filter-color-matrix": "6.5.3",
+        "@pixi/filter-displacement": "6.5.3",
+        "@pixi/filter-fxaa": "6.5.3",
+        "@pixi/filter-noise": "6.5.3",
+        "@pixi/graphics": "6.5.3",
+        "@pixi/interaction": "6.5.3",
+        "@pixi/loaders": "6.5.3",
+        "@pixi/math": "6.5.3",
+        "@pixi/mesh": "6.5.3",
+        "@pixi/mesh-extras": "6.5.3",
+        "@pixi/mixin-cache-as-bitmap": "6.5.3",
+        "@pixi/mixin-get-child-by-name": "6.5.3",
+        "@pixi/mixin-get-global-position": "6.5.3",
+        "@pixi/particle-container": "6.5.3",
+        "@pixi/polyfill": "6.5.3",
+        "@pixi/prepare": "6.5.3",
+        "@pixi/runner": "6.5.3",
+        "@pixi/settings": "6.5.3",
+        "@pixi/sprite": "6.5.3",
+        "@pixi/sprite-animated": "6.5.3",
+        "@pixi/sprite-tiling": "6.5.3",
+        "@pixi/spritesheet": "6.5.3",
+        "@pixi/text": "6.5.3",
+        "@pixi/text-bitmap": "6.5.3",
+        "@pixi/ticker": "6.5.3",
+        "@pixi/utils": "6.5.3"
       }
     },
     "pkg-dir": {
@@ -15786,9 +15790,9 @@
       "dev": true
     },
     "promise-polyfill": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
-      "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
       "dev": true
     },
     "proto-list": {

--- a/package.json
+++ b/package.json
@@ -95,12 +95,12 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.19.3",
+    "@pixi/eslint-config": "^3.0.0",
     "@pixi/webdoc-template": "^1.5.3",
     "@rollup/plugin-typescript": "^8.0.0",
     "@types/chai": "^4.2.16",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.0.0",
-    "@pixi/eslint-config": "^3.0.0",
     "@types/offscreencanvas": "^2019.6.4",
     "@webdoc/cli": "^1.5.5",
     "chai": "^4.2.0",
@@ -116,7 +116,7 @@
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.0",
-    "pixi.js": "^6.2.1",
+    "pixi.js": "^6.5.3",
     "pre-commit": "^1.2.2",
     "rimraf": "^2.6.3",
     "rollup": "^2.0.0",
@@ -125,10 +125,10 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
-    "@pixi/core": ">=5",
-    "@pixi/loaders": ">=5",
-    "@pixi/ticker": ">=5",
-    "@pixi/utils": ">=5"
+    "@pixi/core": ">=5 <7",
+    "@pixi/loaders": ">=5 <7",
+    "@pixi/ticker": ">=5 <7",
+    "@pixi/utils": ">=5 <7"
   },
   "eslintConfig": {
     "extends": [

--- a/src/SoundLoader.ts
+++ b/src/SoundLoader.ts
@@ -8,6 +8,9 @@ import { extensions } from './utils/supported';
  */
 class SoundLoader implements ILoaderPlugin
 {
+    /** Used for PixiJS 6.5.0 extensions API */
+    static extension = 'loader';
+
     /** Install the middleware */
     public static add(): void
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Loader } from '@pixi/loaders';
+import * as core from '@pixi/core';
 import { setInstance } from './instance';
 import { SoundLoader } from './SoundLoader';
 import { SoundLibrary } from './SoundLibrary';
@@ -10,7 +11,16 @@ import * as utils from './utils';
 const sound = setInstance(new SoundLibrary());
 
 // Add the loader plugin
-Loader.registerPlugin(SoundLoader);
+if ('extensions' in core)
+{
+    // Use the new extensions API
+    core.extensions.add(SoundLoader);
+}
+else
+{
+    // fallback to the old API
+    Loader.registerPlugin(SoundLoader);
+}
 
 export * from './Sound';
 export * from './SoundLoader';


### PR DESCRIPTION
### Changes

* Supports the `extensions` API available in PixiJS 6.5.0
* v4 of PixiJS Sound will not be supported in v7, a new major release, this restricts the peers to <7

Fixes #210