### PR TITLE
Provide alternative resolver option for bundlers

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -132,6 +132,16 @@ PIXI.sound.play('bird');</code></pre>
                 </button>
                 <pre><code id="filetypes1" class="javascript">PIXI.Assets.add('applause', 'resources/applause.{ogg,mp3}');
 PIXI.Assets.load('applause').then(sound => sound.play());</code></pre>
+
+                <p>Alternatively, if you don't plan to use Assets (typically because you're using a bundler like Parcel or Webpack), but you still would like to resolve multiple files, you can choose from multiple URLs.</p>
+                <button class="btn btn-danger btn-lg pull-right play" data-code="#filetypes2">
+                    <span class="glyphicon glyphicon-play"></span> Run
+                </button>
+                <pre><code id="filetypes2" class="javascript">const sound = PIXI.sound.add('applause', [
+    'resources/applause.ogg',
+    'resources/applause.mp3'
+]);
+sound.play();</code></pre>
             </div>
             <div class="tab-pane fade" id="section-preloading">
                 <h3>Preloading</h3>

--- a/src/SoundLibrary.ts
+++ b/src/SoundLibrary.ts
@@ -193,6 +193,10 @@ class SoundLibrary
         {
             options = { url: source };
         }
+        else if (Array.isArray(source))
+        {
+            options = { url: source };
+        }
         else if (source instanceof ArrayBuffer || source instanceof AudioBuffer || source instanceof HTMLAudioElement)
         {
             options = { source };


### PR DESCRIPTION
Closes #227

Now instead of using Assets, you can provide multiple URLs

```ts
import musicOpus from './assets/audio/music.opus';
import musicM4a from './assets/audio/music.m4a';
import { sound } from '@pixi/sound';

sound.add('music', [musicOpus, musicM4a]);
```

The above is a shorthand for:
```ts
sound.add('music', { url: [musicOpus, musicM4a] });
```