### PR TITLE
Fix difficulty transpiling filters

### DIFF
--- a/src/filters/DistortionFilter.ts
+++ b/src/filters/DistortionFilter.ts
@@ -17,15 +17,14 @@ class DistortionFilter extends Filter
     /** @param amount - The amount of distoration from 0 to 1. */
     constructor(amount = 0)
     {
-        if (getInstance().useLegacy)
+        let distortion: WaveShaperNode;
+
+        if (!getInstance().useLegacy)
         {
-            super(null);
+            const { audioContext } = getInstance().context;
 
-            return;
+            distortion = audioContext.createWaveShaper();
         }
-
-        const { context } = getInstance();
-        const distortion: WaveShaperNode = context.audioContext.createWaveShaper();
 
         super(distortion);
 
@@ -38,6 +37,10 @@ class DistortionFilter extends Filter
     set amount(value: number)
     {
         this._amount = value;
+        if (getInstance().useLegacy)
+        {
+            return;
+        }
         const scaledValue = value * 1000;
         const samples = 44100;
         const curve: Float32Array = new Float32Array(samples);

--- a/src/filters/EqualizerFilter.ts
+++ b/src/filters/EqualizerFilter.ts
@@ -103,12 +103,7 @@ class EqualizerFilter extends Filter
     constructor(f32 = 0, f64 = 0, f125 = 0, f250 = 0, f500 = 0,
         f1k = 0, f2k = 0, f4k = 0, f8k = 0, f16k = 0)
     {
-        if (getInstance().useLegacy)
-        {
-            super(null);
-
-            return;
-        }
+        let bands: BiquadFilterNode[] = [];
 
         const equalizerBands: Band[] = [
             {
@@ -163,17 +158,20 @@ class EqualizerFilter extends Filter
             },
         ];
 
-        const bands: BiquadFilterNode[] = equalizerBands.map((band: Band) =>
+        if (!getInstance().useLegacy)
         {
-            const node: BiquadFilterNode = getInstance().context.audioContext.createBiquadFilter();
+            bands = equalizerBands.map((band: Band) =>
+            {
+                const node: BiquadFilterNode = getInstance().context.audioContext.createBiquadFilter();
 
-            node.type = band.type as BiquadFilterType;
-            WebAudioUtils.setParamValue(node.Q, 1);
-            node.frequency.value = band.f; // WebAudioUtils.setParamValue(filter.frequency, band.f);
-            WebAudioUtils.setParamValue(node.gain, band.gain);
+                node.type = band.type as BiquadFilterType;
+                WebAudioUtils.setParamValue(node.Q, 1);
+                node.frequency.value = band.f; // WebAudioUtils.setParamValue(filter.frequency, band.f);
+                WebAudioUtils.setParamValue(node.gain, band.gain);
 
-            return node;
-        });
+                return node;
+            });
+        }
 
         // Setup the constructor AudioNode, where first is the input, and last is the output
         super(bands[0], bands[bands.length - 1]);

--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -34,13 +34,13 @@ class Filter
      */
     public connect(destination: AudioNode): void
     {
-        this.source.connect(destination);
+        this.source?.connect(destination);
     }
 
     /** Completely disconnect filter from destination and source nodes. */
     public disconnect(): void
     {
-        this.source.disconnect();
+        this.source?.disconnect();
     }
 
     /** Destroy the filter and don't use after this. */

--- a/src/filters/MonoFilter.ts
+++ b/src/filters/MonoFilter.ts
@@ -13,24 +13,24 @@ class MonoFilter extends Filter
 
     constructor()
     {
-        if (getInstance().useLegacy)
+        let merger: ChannelMergerNode;
+        let splitter: ChannelSplitterNode;
+
+        if (!getInstance().useLegacy)
         {
-            super(null);
+            const { audioContext } = getInstance().context;
 
-            return;
+            splitter = audioContext.createChannelSplitter();
+            merger = audioContext.createChannelMerger();
+            merger.connect(splitter);
         }
-        const audioContext: AudioContext = getInstance().context.audioContext;
-        const splitter: ChannelSplitterNode = audioContext.createChannelSplitter();
-        const merger: ChannelMergerNode = audioContext.createChannelMerger();
-
-        merger.connect(splitter);
         super(merger, splitter);
         this._merger = merger;
     }
 
     public destroy(): void
     {
-        this._merger.disconnect();
+        this._merger?.disconnect();
         this._merger = null;
         super.destroy();
     }

--- a/src/filters/ReverbFilter.ts
+++ b/src/filters/ReverbFilter.ts
@@ -20,15 +20,7 @@ class ReverbFilter extends Filter
      */
     constructor(seconds = 3, decay = 2, reverse = false)
     {
-        if (getInstance().useLegacy)
-        {
-            super(null);
-
-            return;
-        }
-
         super(null);
-
         this._seconds = this._clamp(seconds, 1, 50);
         this._decay = this._clamp(decay, 0, 100);
         this._reverse = reverse;
@@ -95,10 +87,14 @@ class ReverbFilter extends Filter
      */
     private _rebuild(): void
     {
-        const context = getInstance().context.audioContext;
-        const rate: number = context.sampleRate;
+        if (getInstance().useLegacy)
+        {
+            return;
+        }
+        const { audioContext } = getInstance().context;
+        const rate: number = audioContext.sampleRate;
         const length: number = rate * this._seconds;
-        const impulse: AudioBuffer = context.createBuffer(2, length, rate);
+        const impulse: AudioBuffer = audioContext.createBuffer(2, length, rate);
         const impulseL: Float32Array = impulse.getChannelData(0);
         const impulseR: Float32Array = impulse.getChannelData(1);
         let n: number;
@@ -109,7 +105,7 @@ class ReverbFilter extends Filter
             impulseL[i] = ((Math.random() * 2) - 1) * Math.pow(1 - (n / length), this._decay);
             impulseR[i] = ((Math.random() * 2) - 1) * Math.pow(1 - (n / length), this._decay);
         }
-        const convolver = getInstance().context.audioContext.createConvolver();
+        const convolver = audioContext.createConvolver();
 
         convolver.buffer = impulse;
         this.init(convolver);

--- a/src/filters/StereoFilter.ts
+++ b/src/filters/StereoFilter.ts
@@ -21,28 +21,25 @@ class StereoFilter extends Filter
     /** @param pan - The amount of panning, -1 is left, 1 is right, 0 is centered. */
     constructor(pan = 0)
     {
-        if (getInstance().useLegacy)
-        {
-            super(null);
-
-            return;
-        }
-
         let stereo: StereoPannerNode;
         let panner: PannerNode;
         let destination: AudioNode;
-        const { audioContext } = getInstance().context;
 
-        if (audioContext.createStereoPanner)
+        if (!getInstance().useLegacy)
         {
-            stereo = audioContext.createStereoPanner();
-            destination = stereo;
-        }
-        else
-        {
-            panner = audioContext.createPanner();
-            panner.panningModel = 'equalpower';
-            destination = panner;
+            const { audioContext } = getInstance().context;
+
+            if (audioContext.createStereoPanner)
+            {
+                stereo = audioContext.createStereoPanner();
+                destination = stereo;
+            }
+            else
+            {
+                panner = audioContext.createPanner();
+                panner.panningModel = 'equalpower';
+                destination = panner;
+            }
         }
 
         super(destination);
@@ -61,7 +58,7 @@ class StereoFilter extends Filter
         {
             WebAudioUtils.setParamValue(this._stereo.pan, value);
         }
-        else
+        else if (this._panner)
         {
             this._panner.setPosition(value, 0, 1 - Math.abs(value));
         }

--- a/src/filters/StreamFilter.ts
+++ b/src/filters/StreamFilter.ts
@@ -12,18 +12,19 @@ class StreamFilter extends Filter
 
     constructor()
     {
-        if (getInstance().useLegacy)
-        {
-            super(null);
+        let destination: MediaStreamAudioDestinationNode;
+        let source: MediaStreamAudioSourceNode;
 
-            return;
+        if (!getInstance().useLegacy)
+        {
+            const { audioContext } = getInstance().context;
+
+            destination = audioContext.createMediaStreamDestination();
+            source = audioContext.createMediaStreamSource(destination.stream);
         }
-        const audioContext: AudioContext = getInstance().context.audioContext;
-        const destination: MediaStreamAudioDestinationNode = audioContext.createMediaStreamDestination();
-        const source: MediaStreamAudioSourceNode = audioContext.createMediaStreamSource(destination.stream);
 
         super(destination, source);
-        this._stream = destination.stream;
+        this._stream = destination?.stream;
     }
 
     public get stream(): MediaStream

--- a/src/filters/TelephoneFilter.ts
+++ b/src/filters/TelephoneFilter.ts
@@ -11,36 +11,38 @@ class TelephoneFilter extends Filter
 {
     constructor()
     {
-        if (getInstance().useLegacy)
-        {
-            super(null);
+        let destination: AudioNode;
+        let source: AudioNode;
 
-            return;
+        if (!getInstance().useLegacy)
+        {
+            const { audioContext } = getInstance().context;
+            const lpf1 = audioContext.createBiquadFilter();
+            const lpf2 = audioContext.createBiquadFilter();
+            const hpf1 = audioContext.createBiquadFilter();
+            const hpf2 = audioContext.createBiquadFilter();
+
+            lpf1.type = 'lowpass';
+            WebAudioUtils.setParamValue(lpf1.frequency, 2000.0);
+
+            lpf2.type = 'lowpass';
+            WebAudioUtils.setParamValue(lpf2.frequency, 2000.0);
+
+            hpf1.type = 'highpass';
+            WebAudioUtils.setParamValue(hpf1.frequency, 500.0);
+
+            hpf2.type = 'highpass';
+            WebAudioUtils.setParamValue(hpf2.frequency, 500.0);
+
+            lpf1.connect(lpf2);
+            lpf2.connect(hpf1);
+            hpf1.connect(hpf2);
+
+            destination = lpf1;
+            source = hpf2;
         }
 
-        const { audioContext } = getInstance().context;
-        const lpf1 = audioContext.createBiquadFilter();
-        const lpf2 = audioContext.createBiquadFilter();
-        const hpf1 = audioContext.createBiquadFilter();
-        const hpf2 = audioContext.createBiquadFilter();
-
-        lpf1.type = 'lowpass';
-        WebAudioUtils.setParamValue(lpf1.frequency, 2000.0);
-
-        lpf2.type = 'lowpass';
-        WebAudioUtils.setParamValue(lpf2.frequency, 2000.0);
-
-        hpf1.type = 'highpass';
-        WebAudioUtils.setParamValue(hpf1.frequency, 500.0);
-
-        hpf2.type = 'highpass';
-        WebAudioUtils.setParamValue(hpf2.frequency, 500.0);
-
-        lpf1.connect(lpf2);
-        lpf2.connect(hpf1);
-        hpf1.connect(hpf2);
-
-        super(lpf1, hpf2);
+        super(destination, source);
     }
 }
 


### PR DESCRIPTION
User on Discord had problems with transpiling with Babel with `@babel/plugin-transform-parameters` because of the conditional super() calls with the filters. This PR refactors the constructors to rework how to deal with legacy. 

### Before

```js
class DistortionFilter extends Filter {
  constructor(amount = 0) {
    var __super = (...args) => {
      super(...args);
    };
    if (getInstance().useLegacy) {
      __super(null);
      return;
    }
    const { context } = getInstance();
    const distortion = context.audioContext.createWaveShaper();
    __super(distortion);
    this._distortion = distortion;
    this.amount = amount;
  }
}
```

### After 

```js
class DistortionFilter extends Filter {
  constructor(amount = 0) {
    let distortion;
    if (!getInstance().useLegacy) {
      const { audioContext } = getInstance().context;
      distortion = audioContext.createWaveShaper();
    }
    super(distortion);
    this._distortion = distortion;
    this.amount = amount;
  }
}
```