### PR TITLE
Fix auto-pause on focus

### DIFF
--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -121,6 +121,10 @@ class WebAudioContext extends Filterable implements IMediaContext
     /** Handle mobile WebAudio context resume */
     private onFocus(): void
     {
+        if (!this.autoPause)
+        {
+            return;
+        }
         // Safari uses the non-standard "interrupted" state in some cases
         // such as when the app loses focus because the screen is locked
         // or when the user switches to another app.
@@ -136,7 +140,11 @@ class WebAudioContext extends Filterable implements IMediaContext
     /** Handle mobile WebAudio context suspend */
     private onBlur(): void
     {
-        if (!this._locked && this.autoPause)
+        if (!this.autoPause)
+        {
+            return;
+        }
+        if (!this._locked)
         {
             this._pausedOnBlur = this._paused;
             this.paused = true;


### PR DESCRIPTION
Fixes #248

The `focus` window event was refreshing pause state, which is shouldn't. 