### PR TITLE
Let preferUrl respect supported formats

### DIFF
--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -4,7 +4,7 @@ import { HTMLAudioMedia } from './htmlaudio/HTMLAudioMedia';
 import { getInstance } from './instance';
 import { IMedia, IMediaContext, IMediaInstance } from './interfaces';
 import { SoundSprite, SoundSpriteData, SoundSprites } from './SoundSprite';
-import { extensions } from './utils/supported';
+import { extensions, supported } from './utils/supported';
 import { WebAudioMedia } from './webaudio/WebAudioMedia';
 
 /**
@@ -322,11 +322,17 @@ class Sound
      */
     private preferUrl(urls: string[]): string
     {
-        const [{ url }] = urls
+        const [file] = urls
             .map((url) => ({ url, ext: utils.path.extname(url).slice(1) }))
+            .filter(({ ext }) => supported[ext])
             .sort((a, b) => extensions.indexOf(a.ext) - extensions.indexOf(b.ext));
 
-        return url;
+        if (!file)
+        {
+            throw new Error('No supported file type found');
+        }
+
+        return file.url;
     }
 
     /** Instance of the media context. */


### PR DESCRIPTION
Coincidentally stumbled on this: The second example from [here](https://pixijs.io/sound/examples/index.html#section-filetypes) is throwing in Safari (17.0) because it will just try to play the ogg file even though Safari does not support oggs.

It would now throw synchronously if no supported file is found. Previously a Promise got rejected, because the file could not be decoded. Could this change be a problem?