### PR TITLE
Adds `file` property to WebAudioMedia for access to downloaded audio file data.

### DIFF
--- a/src/webaudio/WebAudioMedia.ts
+++ b/src/webaudio/WebAudioMedia.ts
@@ -27,6 +27,11 @@ class WebAudioMedia implements IMedia
     /** Instance of the chain builder. */
     private _nodes: WebAudioNodes;
 
+    /**
+     * Raw audio file data.
+     */
+    public file: Blob;
+
     /** Instance of the source node. */
     private _source: AudioBufferSourceNode;
 
@@ -142,8 +147,10 @@ class WebAudioMedia implements IMedia
     {
         const url: string = this.parent.url;
         const response = await DOMAdapter.get().fetch(url);
-
-        this._decode(await response.arrayBuffer(), callback);
+        const arrayBuffer = await response.arrayBuffer();
+        
+        this.file = new Blob([arrayBuffer]);
+        this._decode(arrayBuffer, callback);
     }
 
     /**


### PR DESCRIPTION
It would be useful to make the raw audio data available from `WebAudioMedia` so things like meta ID3 tags can be accessed without requiring additional network calls. Here is my take, although I'm not sure if this is the best route for other use-cases. If not, it would still be great to have some way to access the response `ArrayBuffer` apart from this class's immediate conversion to an `AudioBuffer`.

If there's a standard way to extend `WebAudioMedia" and have Sound use the extended class instead, that could work as well: I just wasn't sure about how to approach that.