### PR TITLE
feat: Fade in/out sounds over very short times to mitigate pops

### DIFF
--- a/examples/client/filters.js
+++ b/examples/client/filters.js
@@ -11,14 +11,38 @@ const allFilters = [];
 const allFiltersMap = {};
 let controller;
 
+const updatePlayButton = (icon, label) =>
+{
+    const iconElement = $('#play > span');
+
+    iconElement.classList.toggle('glyphicon-play', icon === 'play');
+    iconElement.classList.toggle('glyphicon-pause', icon === 'pause');
+    iconElement.nextSibling.textContent = ` ${label}`;
+};
+
 $('#play').addEventListener('click', function ()
 {
-    sound.play();
+    if (sound.isPlaying)
+    {
+        sound.pause();
+        updatePlayButton('play', 'Resume');
+    }
+    else if (sound.paused)
+    {
+        sound.resume();
+        updatePlayButton('pause', 'Pause');
+    }
+    else
+    {
+        sound.play();
+        updatePlayButton('pause', 'Pause');
+    }
 });
 
 $('#stop').addEventListener('click', function ()
 {
     sound.stop();
+    updatePlayButton('play', 'Play');
 });
 
 try

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -108,6 +108,19 @@ interface PlayOptions
      */
     filters?: Filter[];
     /**
+     * If the volume should be ramped in and out over 20ms on pause/resume.
+     * Can also be set to a value in seconds the audio should be ramped over.
+     *
+     * Please note that long ramp times and repeated pausing/resuming can still
+     * cause audio pops and other oddities as the stop/startcalls overlap.
+     *
+     * Also note that _very_ short ramp times also can create audio pops.
+     *
+     * Reduces chance of "pops" for audio during pause/resume.
+     * Only supported with WebAudio.
+     */
+    pauseResumeRamp?: boolean | number,
+    /**
      * When completed.
      * @type {Function}
      */
@@ -215,10 +228,10 @@ class Sound
     private _volume: number;
 
     /** The internal paused state. */
-    private _paused: boolean;
+    private _paused: boolean = false;
 
     /** The internal muted state. */
-    private _muted: boolean;
+    private _muted: boolean = false;
 
     /** The internal volume. */
     private _loop: boolean;
@@ -617,7 +630,7 @@ class Sound
                     {
                         if (options.loaded)
                         {
-                            options.loaded(err, sound, media);
+                            options.loaded(null, sound, media);
                         }
                         resolve(media);
                     }

--- a/src/htmlaudio/HTMLAudioInstance.ts
+++ b/src/htmlaudio/HTMLAudioInstance.ts
@@ -26,34 +26,34 @@ class HTMLAudioInstance extends EventEmitter implements IMediaInstance
     private _media: HTMLAudioMedia;
 
     /** Playback rate, where 1 is 100%. */
-    private _end: number;
+    private _end: number | null = null;
 
     /** Current instance paused state. */
-    private _paused: boolean;
+    private _paused: boolean = false;
 
     /** Current instance muted state. */
-    private _muted: boolean;
+    private _muted: boolean = false;
 
     /** Current actual paused state. */
-    private _pausedReal: boolean;
+    private _pausedReal: boolean = false;
 
     /** Total length of the audio. */
     private _duration: number;
 
     /** Playback rate, where 1 is 100%. */
-    private _start: number;
+    private _start: number = 0;
 
     /** `true` if the audio is actually playing. */
     private _playing: boolean;
 
     /** Volume for the instance. */
-    private _volume: number;
+    private _volume: number = 1;
 
     /** Speed for the instance. */
-    private _speed: number;
+    private _speed: number = 1;
 
     /** `true` for looping the playback */
-    private _loop: boolean;
+    private _loop: boolean = false;
 
     /** @param parent - Parent element */
     constructor(parent: HTMLAudioMedia)
@@ -221,7 +221,7 @@ class HTMLAudioInstance extends EventEmitter implements IMediaInstance
     {
         console.warn('HTML Audio does not support filters');
 
-        return null;
+        return [];
     }
     public set filters(_filters: Filter[])
     {

--- a/src/interfaces/IMediaInstance.ts
+++ b/src/interfaces/IMediaInstance.ts
@@ -1,3 +1,4 @@
+import { Filter } from '../filters/Filter.js';
 import { PlayOptions } from '../Sound';
 import { IMedia } from './IMedia';
 
@@ -42,6 +43,12 @@ interface IMediaInstance
 
     /** Set the muted state of the instance */
     muted: boolean;
+
+    /**
+     * Array of filters to apply to the sound.
+     * Only supported with WebAudio.
+     */
+    filters: Filter[];
 
     /** Stop the current instance from playing. */
     stop(): void;

--- a/src/webaudio/WebAudioContext.ts
+++ b/src/webaudio/WebAudioContext.ts
@@ -199,7 +199,7 @@ class WebAudioContext extends Filterable implements IMediaContext
      * @type {AudioContext}
      * @readonly
      */
-    public static get AudioContext(): typeof AudioContext
+    public static get AudioContext(): (typeof AudioContext) | null
     {
         const win: any = window as any;
 
@@ -215,7 +215,7 @@ class WebAudioContext extends Filterable implements IMediaContext
      * @type {OfflineAudioContext}
      * @readonly
      */
-    public static get OfflineAudioContext(): typeof OfflineAudioContext
+    public static get OfflineAudioContext(): (typeof OfflineAudioContext) | null
     {
         const win: any = window as any;
 

--- a/src/webaudio/WebAudioInstance.ts
+++ b/src/webaudio/WebAudioInstance.ts
@@ -30,10 +30,10 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
     private _muted: boolean;
 
     /** true if paused. */
-    private _pausedReal: boolean;
+    private _pausedReal: boolean = false;
 
     /** The instance volume */
-    private _volume: number;
+    private _volume: number = 1;
 
     /** Last update frame number. */
     private _lastUpdate: number;
@@ -42,13 +42,13 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
     private _elapsed: number;
 
     /** Playback rate, where 1 is 100%. */
-    private _speed: number;
+    private _speed: number = 1;
 
-    /** Playback rate, where 1 is 100%. */
-    private _end: number;
+    /** Looping end point or duration of section to play */
+    private _end: number | null;
 
     /** `true` if should be looping. */
-    private _loop: boolean;
+    private _loop: boolean = false;
 
     /** Gain node for controlling volume of instance */
     private _gain: GainNode;
@@ -63,7 +63,10 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
     private _source: AudioBufferSourceNode;
 
     /** The filters */
-    private _filters: Filter[];
+    private _filters: Filter[] = [];
+
+    /** If the volume should be ramped on pause/resume */
+    private _pauseResumeRamp: boolean | number = false;
 
     constructor(media: WebAudioMedia)
     {
@@ -169,23 +172,24 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
     {
         if (this._filters)
         {
-            this._filters?.filter((filter) => filter).forEach((filter) => filter.disconnect());
-            this._filters = null;
+            this._filters.filter((filter) => filter).forEach((filter) => filter.disconnect());
             // Reconnect direct path
-            this._source.connect(this._gain);
+            this._source?.connect(this._gain);
         }
-        this._filters = filters?.length ? filters.slice(0) : null;
-        this.refresh();
+        this._filters = filters.slice(0);
+        /**
+         * If the audio never has played and we set a filter there is no need to
+         * refresh as {@link play} will refresh later.
+         */
+        if (this._source)
+        {
+            this.refresh();
+        }
     }
 
     /** Refresh loop, volume and speed based on changes to parent */
     public refresh(): void
     {
-        // Sound could be paused
-        if (!this._source)
-        {
-            return;
-        }
         const global = this._media.context;
         const sound = this._media.parent;
 
@@ -208,7 +212,7 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
     /** Connect filters nodes to audio context */
     private applyFilters(): void
     {
-        if (this._filters?.length)
+        if (this._filters.length)
         {
             // Disconnect direct path before inserting filters
             this._source.disconnect();
@@ -241,7 +245,7 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
             if (pausedReal)
             {
                 // pause the sounds
-                this._internalStop();
+                this._internalPause();
 
                 /**
                  * The sound is paused.
@@ -264,6 +268,7 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
                     speed: this._speed,
                     loop: this._loop,
                     volume: this._volume,
+                    pauseResumeRamp: this._pauseResumeRamp,
                 });
             }
 
@@ -282,23 +287,28 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
      */
     public play(options: PlayOptions): void
     {
-        const { start, end, speed, loop, volume, muted, filters } = options;
+        const { start, end, speed, loop, volume, muted, filters, pauseResumeRamp } = options;
 
         if (end)
         {
             // eslint-disable-next-line no-console
             console.assert(end > start, 'End time is before start time');
         }
+        const { source, gain } = this._pausedReal ? {
+            source: this._source,
+            gain: this._gain,
+        } : this._media.nodes.cloneBufferSource();
+
         this._paused = false;
-        const { source, gain } = this._media.nodes.cloneBufferSource();
 
         this._source = source;
         this._gain = gain;
-        this._speed = speed;
-        this._volume = volume;
+        this._speed = speed ?? this._speed;
+        this._volume = volume ?? this._volume;
         this._loop = !!loop;
-        this._muted = muted;
-        this._filters = filters;
+        this._muted = muted ?? this._muted;
+        this._filters = filters?.slice(0) ?? this._filters;
+        this._pauseResumeRamp = pauseResumeRamp ?? this._pauseResumeRamp;
         this.refresh();
 
         const duration: number = this._source.buffer.duration;
@@ -308,6 +318,18 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
         this._lastUpdate = this._now();
         this._elapsed = start;
         this._source.onended = this._onComplete.bind(this);
+
+        if (this._pauseResumeRamp)
+        {
+            const previousGain = this._gain.gain.value;
+
+            WebAudioUtils.setParamValue(this._gain.gain, 0);
+            WebAudioUtils.linearRampToParamValue(
+                this._gain.gain,
+                previousGain,
+                typeof this._pauseResumeRamp === 'number' ? this._pauseResumeRamp : 0.02,
+            );
+        }
 
         if (this._loop)
         {
@@ -361,8 +383,8 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
 
     public set paused(paused: boolean)
     {
-        this._paused = paused;
         this.refreshPaused();
+        this._paused = paused;
     }
 
     /** Don't use after this. */
@@ -381,8 +403,8 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
             this._media.context.events.off('refreshPaused', this.refreshPaused, this);
             this._media = null;
         }
-        this._filters?.forEach((filter) => filter.disconnect());
-        this._filters = null;
+        this._filters.forEach((filter) => filter.disconnect());
+        this._filters = [];
         this._end = null;
         this._speed = 1;
         this._volume = 1;
@@ -468,6 +490,29 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
         media.context.events.on('refreshPaused', this.refreshPaused, this);
     }
 
+    private _internalPause(): void
+    {
+        if (!this._source || this._paused)
+        {
+            return;
+        }
+
+        this.enableTicker(false);
+        this._source.onended = null;
+
+        if (this._pauseResumeRamp)
+        {
+            const rampTime = this._pauseResumeRamp === true ? 0.02 : this._pauseResumeRamp;
+
+            WebAudioUtils.linearRampToParamValue(this._gain.gain, 0, rampTime);
+            this._source.stop(this._media.context.audioContext.currentTime + rampTime + 0.001);
+        }
+        else
+        {
+            this._source.stop(this._media.context.audioContext.currentTime);
+        }
+    }
+
     /** Stops the instance. */
     private _internalStop(): void
     {
@@ -475,7 +520,7 @@ class WebAudioInstance extends EventEmitter implements IMediaInstance
         {
             this.enableTicker(false);
             this._source.onended = null;
-            this._source.stop(0); // param needed for iOS 8 bug
+            this._source.stop(this._media.context.audioContext.currentTime);
             this._source.disconnect();
             try
             {

--- a/src/webaudio/WebAudioUtils.ts
+++ b/src/webaudio/WebAudioUtils.ts
@@ -13,19 +13,47 @@ class WebAudioUtils
      * in all environments (e.g., Android webview), so we fallback to the `value` setter.
      * @param param - AudioNode parameter object
      * @param value - Value to set
+     * @param time - Time delay in seconds
      * @return The value set
      */
-    public static setParamValue(param: AudioParam, value: number): number
+    public static setParamValue(param: AudioParam, value: number, time = 0): number
     {
         if (param.setValueAtTime)
         {
             const context = getInstance().context as WebAudioContext;
 
-            param.setValueAtTime(value, context.audioContext.currentTime);
+            param.setValueAtTime(value, context.audioContext.currentTime + time);
         }
         else
         {
             param.value = value;
+        }
+
+        return value;
+    }
+
+    /**
+     * Linearly ramp from the current to a new AudioParam value.
+     * Use `linearRampToValueAtTime` when available. Otherwise fallback to
+     * setting it using {@link WebAudioUtils.setParamValue}.
+     * @param param - AudioNode parameter object
+     * @param value - Value to ramp to
+     * @param time - Time in seconds the ramping should occur
+     * @returns The value set
+     */
+    public static linearRampToParamValue(param: AudioParam, value: number, time: number): number
+    {
+        if (param.linearRampToValueAtTime)
+        {
+            const context = getInstance().context as WebAudioContext;
+
+            // We need to setValueAtTime before we linearRamp or there is no "event" to ramp from.
+            param.setValueAtTime(param.value, context.audioContext.currentTime);
+            param.linearRampToValueAtTime(value, context.audioContext.currentTime + time);
+        }
+        else
+        {
+            WebAudioUtils.setParamValue(param, value, time);
         }
 
         return value;

--- a/test/htmlaudio.test.ts
+++ b/test/htmlaudio.test.ts
@@ -1,3 +1,47 @@
+import path from 'node:path';
+import { Sound } from '../src';
+import { HTMLAudioInstance } from '../src/htmlaudio/HTMLAudioInstance';
+import { WebAudioContext } from '../src/webaudio/WebAudioContext';
 import { suite } from './suite';
 
 suite(true);
+
+describe(`HTMLAudioInstance`, () =>
+{
+    let mockAudioContext: jest.SpyInstance;
+    let warningMock: jest.SpyInstance;
+
+    beforeAll(() =>
+    {
+        warningMock = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockAudioContext = jest.spyOn(WebAudioContext, 'AudioContext', 'get').mockReturnValue(null);
+    });
+
+    afterAll(() =>
+    {
+        mockAudioContext.mockRestore();
+        warningMock.mockRestore();
+    });
+
+    let instance: HTMLAudioInstance;
+
+    beforeEach(async () =>
+    {
+        const mediaInstance = Sound.from({
+            url: path.join(__dirname, 'resources, alert-4.mp3'),
+        }).media;
+
+        await new Promise<void>((resolve) => mediaInstance.load(() => resolve()));
+
+        instance = mediaInstance.create() as HTMLAudioInstance;
+    });
+
+    it('should match type hinting without having being interacted with', () =>
+    {
+        expect(instance.speed).toBe(1);
+        expect(instance.volume).toBe(1);
+        expect(instance.muted).toBe(false);
+        expect(instance.loop).toBe(false);
+        expect(instance.filters).toEqual([]);
+    });
+});

--- a/test/suite.ts
+++ b/test/suite.ts
@@ -377,39 +377,39 @@ function suite(useLegacy = false): void
             Sound.from({
                 url: manifest.silence,
                 preload: true,
-                loaded: (err, snd) =>
+                loaded: async (err, snd) =>
                 {
                     expect(err).toBe(null);
+                    expect(snd).not.toBe(undefined);
 
                     const filter = new filters.TelephoneFilter();
-                    const instance = snd?.play({
+                    const instance = await snd!.play({
                         filters: [filter],
                     });
-                    const instance2 = snd?.play();
+                    const instance2 = await snd!.play();
 
                     if (useLegacy)
                     {
-                        // eslint-disable-next-line @typescript-eslint/no-empty-function
-                        const spy = jest.spyOn(console, 'warn').mockImplementation(() => { });
+                        const spy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-                        expect((instance as any).filters).toBe(null);
-                        expect((instance2 as any).filters).toBe(null);
+                        expect((instance as any).filters).toEqual([]);
+                        expect((instance2 as any).filters).toEqual([]);
                         spy.mockRestore();
                     }
                     else
                     {
                         expect(instance).toBeInstanceOf(webaudio.WebAudioInstance);
                         expect(instance2).toBeInstanceOf(webaudio.WebAudioInstance);
-                        expect((instance as webaudio.WebAudioInstance).filters).toBeInstanceOf(Array);
-                        expect((instance as webaudio.WebAudioInstance).filters.length).toBe(1);
-                        expect((instance as webaudio.WebAudioInstance).filters[0]).toBe(filter);
-                        expect((instance as webaudio.WebAudioInstance).progress).toBeLessThan(1);
-                        (instance as webaudio.WebAudioInstance).filters = null as any;
-                        expect((instance as webaudio.WebAudioInstance).filters).toBe(null);
-                        expect((instance as webaudio.WebAudioInstance).progress).toBeLessThan(1);
-                        expect((instance2 as webaudio.WebAudioInstance).filters).toBeUndefined();
-                        (instance2 as webaudio.WebAudioInstance).destroy();
-                        expect((instance2 as webaudio.WebAudioInstance).filters).toBe(null);
+                        expect(instance.filters).toBeInstanceOf(Array);
+                        expect(instance.filters).toHaveLength(1);
+                        expect(instance.filters[0]).toBe(filter);
+                        expect(instance.progress).toBeLessThan(1);
+                        instance.filters = [];
+                        expect(instance.filters).toEqual([]);
+                        expect(instance.progress).toBeLessThan(1);
+                        expect(instance2.filters).toEqual([]);
+                        instance2.destroy();
+                        expect(instance2.filters).toEqual([]);
                     }
                     done();
                 }

--- a/test/webaudio.test.ts
+++ b/test/webaudio.test.ts
@@ -1,4 +1,6 @@
-import { filters } from '../src';
+import { scheduler } from 'node:timers/promises';
+import { filters, Sound } from '../src';
+import { WebAudioInstance } from '../src/webaudio/WebAudioInstance';
 import { suite } from './suite';
 
 suite(false);
@@ -10,5 +12,91 @@ describe(`filters.DistortionFilter`, () =>
         const filter = new filters.DistortionFilter(0.5);
 
         expect(filter.amount).toBe(0.5);
+    });
+});
+
+describe(`WebAudioInstance`, () =>
+{
+    let instance: WebAudioInstance;
+
+    beforeEach(() =>
+    {
+        const context = new AudioContext({ sampleRate: 8000 });
+
+        // Creates a 3 second long silent sound source
+        const source = context.createBuffer(1, context.sampleRate * 3, context.sampleRate);
+
+        const media = Sound.from({ source }).media;
+
+        // If we don't loead media here there is no sound buffer to look at later.
+        media.load();
+        instance = media.create() as WebAudioInstance;
+    });
+
+    afterEach(() =>
+    {
+        instance.destroy();
+    });
+
+    it('should match type hinting without having being interacted with', () =>
+    {
+        expect(instance.speed).toBe(1);
+        expect(instance.volume).toBe(1);
+        expect(instance.muted).toBe(false);
+        expect(instance.loop).toBe(false);
+        expect(instance.filters).toEqual([]);
+    });
+
+    it('should not keep a reference to the assigned filter array', () =>
+    {
+        const filter1 = new filters.DistortionFilter(0.5);
+        const filter2 = new filters.DistortionFilter(0.5);
+        const instanceFilters = [filter1];
+
+        instance.filters = instanceFilters;
+        expect(instance.filters).toHaveLength(1);
+        expect(instance.filters).toContain(filter1);
+        expect(instance.filters).not.toBe(instanceFilters);
+
+        instanceFilters.push(filter2);
+
+        expect(instance.filters).not.toContain(filter2);
+    });
+
+    it('should not keep a reference to the assigned filter array when filter is assigned through playOptions', async () =>
+    {
+        const filter1 = new filters.DistortionFilter(0.5);
+        const instanceFilters = [filter1];
+
+        instance.play({ filters: instanceFilters });
+
+        expect(instance.filters).not.toBe(instanceFilters);
+    });
+
+    it('should allow array functions on the filter array', () =>
+    {
+        const filter = new filters.DistortionFilter(0.5);
+
+        instance.filters.push(filter);
+
+        expect(instance.filters).toContain(filter);
+
+        instance.filters.pop();
+
+        expect(instance.filters).toHaveLength(0);
+    });
+
+    it('should ramp out gain on pause', async () =>
+    {
+        instance.play({ pauseResumeRamp: 20 });
+
+        await scheduler.yield();
+
+        instance.paused = true;
+
+        await scheduler.yield();
+
+        expect((instance as any)._gain.gain.value).toBeLessThanOrEqual(1);
+        expect((instance as any)._gain.gain.value).toBeGreaterThan(0);
     });
 });


### PR DESCRIPTION
When pausing and resuming a bunch of sounds I've noticed the occasional "audio pop". I have tried to mitigate this by allowing sounds to ramp in volume over a few milliseconds rather than changing gain instantly. The old behavior remains the default.

I've also allowed the filter view to play/pause sounds as it was very helpful in troubleshooting and felt a waste to undo (I still can undo it if it is unwanted).

In addition I've changed the initial value for a few parameters as I've kept running into issue where I want to use, for example, the filter array as an array, but it is sometimes undefined and sometimes null in conflict with its type hint.